### PR TITLE
Fixes building on a Mac using Homebrew as package manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ ifeq (Darwin,$(findstring Darwin,$(shell uname)))
 	# add macports/homebrew include and library path to search directories, don't use '-rdynamic' and '-lrt':
 	CXXFLAGS += -I/opt/local/include -I/usr/local/opt/readline/include
 	LDFLAGS += -L/opt/local/lib -L/usr/local/opt/readline/lib
+	# add homebrew's libffi include and library path
+	CXXFLAGS += $(shell PKG_CONFIG_PATH=$$(brew list libffi | grep pkgconfig | xargs dirname) pkg-config --silence-errors --cflags libffi)
+	LDFLAGS += $(shell PKG_CONFIG_PATH=$$(brew list libffi | grep pkgconfig | xargs dirname) pkg-config --silence-errors --libs libffi)
 	SED = gsed
 else
 	LDFLAGS += -rdynamic

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ ifeq (Darwin,$(findstring Darwin,$(shell uname)))
 	# add homebrew's libffi include and library path
 	CXXFLAGS += $(shell PKG_CONFIG_PATH=$$(brew list libffi | grep pkgconfig | xargs dirname) pkg-config --silence-errors --cflags libffi)
 	LDFLAGS += $(shell PKG_CONFIG_PATH=$$(brew list libffi | grep pkgconfig | xargs dirname) pkg-config --silence-errors --libs libffi)
+	# use bison installed by homebrew if available
+	BISON = $(shell (brew list bison | grep -m1 "bin/bison") || echo bison)
 	SED = gsed
 else
 	LDFLAGS += -rdynamic

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ CXXFLAGS = -Wall -Wextra -ggdb -I"$(shell pwd)" -MD -DYOSYS_SRC='"$(shell pwd)"'
 LDFLAGS = -L${DESTDIR}/lib
 LDLIBS = -lstdc++ -lm
 SED = sed
+BISON = bison
 
 ifeq (Darwin,$(findstring Darwin,$(shell uname)))
 	# add macports/homebrew include and library path to search directories, don't use '-rdynamic' and '-lrt':

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ LDLIBS = -lstdc++ -lm
 SED = sed
 
 ifeq (Darwin,$(findstring Darwin,$(shell uname)))
-	# add macports include and library path to search directories, don't use '-rdynamic' and '-lrt':
-	CXXFLAGS += -I/opt/local/include
-	LDFLAGS += -L/opt/local/lib
+	# add macports/homebrew include and library path to search directories, don't use '-rdynamic' and '-lrt':
+	CXXFLAGS += -I/opt/local/include -I/usr/local/opt/readline/include
+	LDFLAGS += -L/opt/local/lib -L/usr/local/opt/readline/lib
 	SED = gsed
 else
 	LDFLAGS += -rdynamic

--- a/frontends/ilang/Makefile.inc
+++ b/frontends/ilang/Makefile.inc
@@ -5,7 +5,7 @@ GENFILES += frontends/ilang/ilang_parser.output
 GENFILES += frontends/ilang/ilang_lexer.cc
 
 frontends/ilang/ilang_parser.tab.cc: frontends/ilang/ilang_parser.y
-	$(P) bison -d -r all -b frontends/ilang/ilang_parser frontends/ilang/ilang_parser.y
+	$(P) $(BISON) -d -r all -b frontends/ilang/ilang_parser frontends/ilang/ilang_parser.y
 	$(Q) mv frontends/ilang/ilang_parser.tab.c frontends/ilang/ilang_parser.tab.cc
 
 frontends/ilang/ilang_parser.tab.h: frontends/ilang/ilang_parser.tab.cc

--- a/frontends/verilog/Makefile.inc
+++ b/frontends/verilog/Makefile.inc
@@ -5,7 +5,7 @@ GENFILES += frontends/verilog/verilog_parser.output
 GENFILES += frontends/verilog/verilog_lexer.cc
 
 frontends/verilog/verilog_parser.tab.cc: frontends/verilog/verilog_parser.y
-	$(P) bison -d -r all -b frontends/verilog/verilog_parser frontends/verilog/verilog_parser.y
+	$(P) $(BISON) -d -r all -b frontends/verilog/verilog_parser frontends/verilog/verilog_parser.y
 	$(Q) mv frontends/verilog/verilog_parser.tab.c frontends/verilog/verilog_parser.tab.cc
 
 frontends/verilog/verilog_parser.tab.h: frontends/verilog/verilog_parser.tab.cc


### PR DESCRIPTION
Correctly finds and uses Homebrew's installation of libreadline/libffi/bison.