### PR TITLE
Add "echo-yosys-ver" and "echo-git-rev" Makefile targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,12 @@ config-gprof: clean
 config-sudo:
 	echo "INSTALL_SUDO := sudo" >> Makefile.conf
 
+echo-yosys-ver:
+	@echo "$(YOSYS_VER)"
+
+echo-git-rev:
+	@echo "$(GIT_REV)"
+
 -include libs/*/*.d
 -include frontends/*/*.d
 -include passes/*/*.d


### PR DESCRIPTION
These Makefile targets simply echo the corresponding Makefile variable,
simplifying package build scripts.

Signed-off-by: Martin Schmölzer <mschmoelzer@gmail.com>