### PR TITLE
In test scripts changed python to python2.

### DIFF
--- a/techlibs/ice40/Makefile.inc
+++ b/techlibs/ice40/Makefile.inc
@@ -11,7 +11,7 @@ EXTRA_OBJS += techlibs/ice40/brams_init.mk
 .SECONDARY: techlibs/ice40/brams_init.mk
 
 techlibs/ice40/brams_init.mk: techlibs/ice40/brams_init.py
-	cd techlibs/ice40 && python brams_init.py
+	cd techlibs/ice40 && python2 brams_init.py
 	touch techlibs/ice40/brams_init.mk
 
 techlibs/ice40/brams_init1.vh: techlibs/ice40/brams_init.mk

--- a/tests/bram/run-test.sh
+++ b/tests/bram/run-test.sh
@@ -8,7 +8,7 @@ rm -rf temp
 mkdir -p temp
 
 echo "generating tests.."
-python generate.py
+python2 generate.py
 
 {
 	echo -n "all:"

--- a/tests/fsm/run-test.sh
+++ b/tests/fsm/run-test.sh
@@ -8,7 +8,7 @@ set -e
 rm -rf temp
 mkdir -p temp
 echo "generating tests.."
-python generate.py
+python2 generate.py
 
 {
 	all_targets="all_targets:"

--- a/tests/realmath/run-test.sh
+++ b/tests/realmath/run-test.sh
@@ -4,7 +4,7 @@ set -e
 rm -rf temp
 mkdir -p temp
 echo "generating tests.."
-python generate.py
+python2 generate.py
 
 cd temp
 echo "running tests.."

--- a/tests/share/run-test.sh
+++ b/tests/share/run-test.sh
@@ -8,7 +8,7 @@ set -e
 rm -rf temp
 mkdir -p temp
 echo "generating tests.."
-python generate.py
+python2 generate.py
 
 echo "running tests.."
 for i in $( ls temp/*.ys | sed 's,[^0-9],,g; s,^0*\(.\),\1,g;' ); do


### PR DESCRIPTION
On my system (archlinux), python is a symlink to python3 by default. The yosys test scripts used in "make test" are written in python2 syntax and error out when called from python3, so this just make python2 explicit.