### PR TITLE
Bug fix in $mem verilog backend + changed tests/bram flow of make test.

### DIFF
--- a/tests/bram/run-single.sh
+++ b/tests/bram/run-single.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
-../../yosys -qq -p "proc; opt; memory -nomap -bram temp/brams_${2}.txt; opt -fast -full" \
-		-l temp/synth_${1}_${2}.log -o temp/synth_${1}_${2}.v temp/brams_${1}.v
+../../yosys -qq -p "proc; opt; memory -nomap -bram temp/brams_${2}.txt; opt -fast -full; write_verilog temp/synth_${1}_${2}_stage0.v" \
+		-l temp/synth_${1}_${2}_stage0.log temp/brams_${1}.v
+../../yosys -qq -p "proc; opt; memory -nomap; opt -fast -full; write_verilog -nomem temp/synth_${1}_${2}.v" \
+		-l temp/synth_${1}_${2}.log temp/synth_${1}_${2}_stage0.v
 iverilog -Dvcd_file=\"temp/tb_${1}_${2}.vcd\" -DSIMLIB_MEMDELAY=1ns -o temp/tb_${1}_${2}.tb temp/brams_${1}_tb.v \
 		temp/brams_${1}_ref.v temp/synth_${1}_${2}.v temp/brams_${2}.v ../../techlibs/common/simlib.v
 temp/tb_${1}_${2}.tb > temp/tb_${1}_${2}.txt

--- a/tests/bram/run-single.sh
+++ b/tests/bram/run-single.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -e
-../../yosys -qq -p "proc; opt; memory -nomap -bram temp/brams_${2}.txt; opt -fast -full; write_verilog temp/synth_${1}_${2}_stage0.v" \
-		-l temp/synth_${1}_${2}_stage0.log temp/brams_${1}.v
-../../yosys -qq -p "proc; opt; memory -nomap; opt -fast -full; write_verilog -nomem temp/synth_${1}_${2}.v" \
-		-l temp/synth_${1}_${2}.log temp/synth_${1}_${2}_stage0.v
+../../yosys -qq -p "proc; opt; memory -nomap -bram temp/brams_${2}.txt; opt -fast -full" \
+		-l temp/synth_${1}_${2}.log -o temp/synth_${1}_${2}.v temp/brams_${1}.v
 iverilog -Dvcd_file=\"temp/tb_${1}_${2}.vcd\" -DSIMLIB_MEMDELAY=1ns -o temp/tb_${1}_${2}.tb temp/brams_${1}_tb.v \
 		temp/brams_${1}_ref.v temp/synth_${1}_${2}.v temp/brams_${2}.v ../../techlibs/common/simlib.v
 temp/tb_${1}_${2}.tb > temp/tb_${1}_${2}.txt


### PR DESCRIPTION
Hi Clifford,
This should *finally* complete the $mem cell portion of the verilog backend. This was a pain in the butt, but mostly because of the simulation differences in tests/bram.
I've tried to use your advice given on my reddit question (at least the way I understood it) and had to change the command sequence in tests/bram/run_single.sh

The flow of test/bram is now:
1. attempt to map to brams (as it was before)
2. any memories that were not matched to a bram fall through and the output verilog is written to file (using the new $mem code)
3. read the verilog back into yosys, combine into $mem cells, write the verilog back to file, but this time don't use the new $mem cell code; this allows the $mem cells to be defined by simlib.v and should also test the generated code

Using this flow I have been able to get "make test" to pass, where is was not passing before due to the race conditions.