### PR TITLE
Added iCE40 WARMBOOT cell

### DIFF
--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -864,3 +864,13 @@ module SB_PLL40_2F_PAD (
 	parameter EXTERNAL_DIVIDE_FACTOR = 1;
 endmodule
 
+// SiliconBlue Device Configuration Cells
+
+(* blackbox *)
+(* keep *)
+module SB_WARMBOOT (
+	input BOOT,
+	input S1,
+	input S0
+);
+endmodule


### PR DESCRIPTION
This change adds SB_WARMBOOT to the known blackboxes on iCE40.

It goes well with cseed/arachne-pnr#7.  :-)