### PR TITLE
Microsoft Visual C++ 2013 fixes, 64-bit build.

### DIFF
--- a/kernel/bitpattern.h
+++ b/kernel/bitpattern.h
@@ -30,7 +30,7 @@ struct BitPatternPool
 	int width;
 	struct bits_t {
 		std::vector<RTLIL::State> bitdata;
-		unsigned int cached_hash;
+		mutable unsigned int cached_hash;
 		bits_t(int width = 0) : bitdata(width), cached_hash(0) { }
 		RTLIL::State &operator[](int index) {
 			return bitdata[index];
@@ -45,7 +45,7 @@ struct BitPatternPool
 		}
 		unsigned int hash() const {
 			if (!cached_hash)
-				((bits_t*)this)->cached_hash = hash_ops<std::vector<RTLIL::State>>::hash(bitdata);
+				cached_hash = hash_ops<std::vector<RTLIL::State>>::hash(bitdata);
 			return cached_hash;
 		}
 	};

--- a/kernel/hashlib.h
+++ b/kernel/hashlib.h
@@ -63,17 +63,20 @@ struct hash_int_ops {
 	static inline bool cmp(T a, T b) {
 		return a == b;
 	}
+};
+
+template<> struct hash_ops<int32_t> : hash_int_ops
+{
 	static inline unsigned int hash(int32_t a) {
 		return a;
 	}
+};
+template<> struct hash_ops<int64_t> : hash_int_ops
+{
 	static inline unsigned int hash(int64_t a) {
 		return mkhash(a, a >> 32);
 	}
 };
-
-template<> struct hash_ops<int> : hash_int_ops {};
-template<> struct hash_ops<long> : hash_int_ops {};
-template<> struct hash_ops<long long> : hash_int_ops {};
 
 template<> struct hash_ops<std::string> {
 	static inline bool cmp(const std::string &a, const std::string &b) {
@@ -118,10 +121,9 @@ template<typename T> struct hash_ops<std::vector<T>> {
 		return a == b;
 	}
 	static inline unsigned int hash(std::vector<T> a) {
-		hash_ops<T> t_ops;
 		unsigned int h = mkhash_init;
 		for (auto k : a)
-			h = mkhash(h, t_ops.hash(k));
+			h = mkhash(h, hash_ops<T>::hash(k));
 		return h;
 	}
 };

--- a/kernel/log.h
+++ b/kernel/log.h
@@ -29,6 +29,11 @@
 #  include <sys/resource.h>
 #endif
 
+#if defined(_MSC_VER)
+// At least this is not in MSVC++ 2013.
+#  define __PRETTY_FUNCTION__ __FUNCTION__
+#endif
+
 // from libs/sha1/sha1.h
 class SHA1;
 

--- a/libs/bigint/BigInteger.cc
+++ b/libs/bigint/BigInteger.cc
@@ -53,6 +53,7 @@ BigInteger::BigInteger(const BigUnsigned &x, Sign s) : mag(x) {
  * negative BigInteger instead of an exception. */
 
 // Done longhand to let us use initialization.
+BigInteger::BigInteger(unsigned long long  x) : mag(x) { sign = mag.isZero() ? zero : positive; }
 BigInteger::BigInteger(unsigned long  x) : mag(x) { sign = mag.isZero() ? zero : positive; }
 BigInteger::BigInteger(unsigned int   x) : mag(x) { sign = mag.isZero() ? zero : positive; }
 BigInteger::BigInteger(unsigned short x) : mag(x) { sign = mag.isZero() ? zero : positive; }
@@ -74,6 +75,7 @@ namespace {
 	}
 }
 
+BigInteger::BigInteger(long long   x) : sign(signOf(x)), mag(magOf<long long, unsigned long long>(x)) {}
 BigInteger::BigInteger(long  x) : sign(signOf(x)), mag(magOf<long , unsigned long >(x)) {}
 BigInteger::BigInteger(int   x) : sign(signOf(x)), mag(magOf<int  , unsigned int  >(x)) {}
 BigInteger::BigInteger(short x) : sign(signOf(x)), mag(magOf<short, unsigned short>(x)) {}

--- a/libs/bigint/BigInteger.hh
+++ b/libs/bigint/BigInteger.hh
@@ -54,6 +54,8 @@ public:
 	}
 
 	// Constructors from primitive integer types
+	BigInteger(unsigned long long  x);
+	BigInteger(         long long  x);
 	BigInteger(unsigned long  x);
 	BigInteger(         long  x);
 	BigInteger(unsigned int   x);

--- a/libs/bigint/BigUnsigned.cc
+++ b/libs/bigint/BigUnsigned.cc
@@ -5,9 +5,11 @@
 // The templates used by these constructors and converters are at the bottom of
 // BigUnsigned.hh.
 
+BigUnsigned::BigUnsigned(unsigned long long  x) { initFromPrimitive (x); }
 BigUnsigned::BigUnsigned(unsigned long  x) { initFromPrimitive      (x); }
 BigUnsigned::BigUnsigned(unsigned int   x) { initFromPrimitive      (x); }
 BigUnsigned::BigUnsigned(unsigned short x) { initFromPrimitive      (x); }
+BigUnsigned::BigUnsigned(    long long  x) { initFromSignedPrimitive(x); }
 BigUnsigned::BigUnsigned(         long  x) { initFromSignedPrimitive(x); }
 BigUnsigned::BigUnsigned(         int   x) { initFromSignedPrimitive(x); }
 BigUnsigned::BigUnsigned(         short x) { initFromSignedPrimitive(x); }


### PR DESCRIPTION
These are C++ source code changes only; no build scripts, no project files.

Only 64-bit build tested.

There are about 10000 compiler warnings about possible loss of data when converting size_t to unsigned int, etc.