### PR TITLE
Fix a segfault in dffinit when the value has too few bits

### DIFF
--- a/passes/techmap/dffinit.cc
+++ b/passes/techmap/dffinit.cc
@@ -100,7 +100,7 @@ struct DffinitPass : public Pass {
 					for (int i = 0; i < GetSize(sig); i++) {
 						if (init_bits.count(sig[i]) == 0)
 							continue;
-						while (GetSize(value.bits) < i)
+						while (GetSize(value.bits) <= i)
 							value.bits.push_back(State::S0);
 						value.bits[i] = init_bits.at(sig[i]);
 						cleanup_bits.insert(sig[i]);


### PR DESCRIPTION
The code was already trying to add the required number of bits, but
fell one short of the mark.

The vector needs to hold at least i+1 elements for bits[i] to be valid.