### PR TITLE
More RTLIL performance improvements

### DIFF
--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -379,7 +379,7 @@ struct AST_INTERNAL::ProcessGenerator
 	// e.g. when the last statement in the code "a = 23; if (b) a = 42; a = 0;" is processed this
 	// function is called to clean up the first two assignments as they are overwritten by
 	// the third assignment.
-	void removeSignalFromCaseTree(const std::set<RTLIL::SigBit> &pattern, RTLIL::CaseRule *cs)
+	void removeSignalFromCaseTree(const RTLIL::SigSpec &pattern, RTLIL::CaseRule *cs)
 	{
 		for (auto it = cs->actions.begin(); it != cs->actions.end(); it++)
 			it->first.remove2(pattern, &it->second);
@@ -434,7 +434,7 @@ struct AST_INTERNAL::ProcessGenerator
 						subst_rvalue_map.set(unmapped_lvalue[i], rvalue[i]);
 				}
 
-				removeSignalFromCaseTree(lvalue.to_sigbit_set(), current_case);
+				removeSignalFromCaseTree(lvalue, current_case);
 				remove_unwanted_lvalue_bits(lvalue, rvalue);
 				current_case->actions.push_back(RTLIL::SigSig(lvalue, rvalue));
 			}
@@ -511,7 +511,7 @@ struct AST_INTERNAL::ProcessGenerator
 					subst_rvalue_map.set(this_case_eq_lvalue[i], this_case_eq_ltemp[i]);
 
 				this_case_eq_lvalue.replace(subst_lvalue_map.stdmap());
-				removeSignalFromCaseTree(this_case_eq_lvalue.to_sigbit_set(), current_case);
+				removeSignalFromCaseTree(this_case_eq_lvalue, current_case);
 				addChunkActions(current_case->actions, this_case_eq_lvalue, this_case_eq_ltemp);
 			}
 			break;

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2584,18 +2584,26 @@ void RTLIL::SigSpec::replace(const RTLIL::SigSpec &pattern, const RTLIL::SigSpec
 
 void RTLIL::SigSpec::replace(const RTLIL::SigSpec &pattern, const RTLIL::SigSpec &with, RTLIL::SigSpec *other) const
 {
+	log_assert(other != NULL);
+	log_assert(width_ == other->width_);
 	log_assert(pattern.width_ == with.width_);
 
 	pattern.unpack();
 	with.unpack();
+	unpack();
+	other->unpack();
 
-	dict<RTLIL::SigBit, RTLIL::SigBit> rules;
+	for (int i = 0; i < GetSize(pattern.bits_); i++) {
+		if (pattern.bits_[i].wire != NULL) {
+			for (int j = 0; j < GetSize(bits_); j++) {
+				if (bits_[j] == pattern.bits_[i]) {
+					other->bits_[j] = with.bits_[i];
+				}
+			}
+		}
+	}
 
-	for (int i = 0; i < GetSize(pattern.bits_); i++)
-		if (pattern.bits_[i].wire != NULL)
-			rules[pattern.bits_[i]] = with.bits_[i];
-
-	replace(rules, other);
+	other->check();
 }
 
 void RTLIL::SigSpec::replace(const dict<RTLIL::SigBit, RTLIL::SigBit> &rules)

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -2573,8 +2573,18 @@ void RTLIL::SigSpec::sort()
 
 void RTLIL::SigSpec::sort_and_unify()
 {
+	unpack();
 	cover("kernel.rtlil.sigspec.sort_and_unify");
-	*this = this->to_sigbit_set();
+
+	// A copy of the bits vector is used to prevent duplicating the logic from
+	// SigSpec::SigSpec(std::vector<SigBit>).  This incurrs an extra copy but
+	// that isn't showing up as significant in profiles.
+	std::vector<SigBit> unique_bits = bits_;
+	std::sort(unique_bits.begin(), unique_bits.end());
+	auto last = std::unique(unique_bits.begin(), unique_bits.end());
+	unique_bits.erase(last, unique_bits.end());
+
+	*this = unique_bits;
 }
 
 void RTLIL::SigSpec::replace(const RTLIL::SigSpec &pattern, const RTLIL::SigSpec &with)


### PR DESCRIPTION
More changes to avoid unnecessary copies and memory allocations.  I've been using the following module and synthesizing to Xilinx as the test case:
    module test(
      input wire clock
    );

    parameter ITERATIONS = 1600;

    reg buffer[0:ITERATIONS-1];

    always @(posedge clock) begin : GENERATE
      integer ii;
      for (ii = 0; ii < ITERATIONS; ii = ii + 1) begin
        buffer[ii] <= 1'b0;
      end
    end

    endmodule

Building at commit 5462399c880c4736d0382bf5ba294e97637b393d, read_verilog+synth_xilinx took 79s as reported by yosys.  With these changes, it now takes 22s.