### PR TITLE
Support calling out to an external ABC.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ ABCREV = ae7d65e71adc
 ABCPULL = 1
 ABCMKARGS = CC="$(CXX)" CXX="$(CXX)"
 
+# set ABCEXTERNAL = "abc-command" to use an external ABC instance
+# Note: The in-tree ABC (yosys-abc) will not be installed when ABCEXTERNAL is set.
+ABCEXTERNAL =
+
 define newline
 
 
@@ -204,7 +208,11 @@ endif
 
 ifeq ($(ENABLE_ABC),1)
 CXXFLAGS += -DYOSYS_ENABLE_ABC
+ifeq ($(ABCEXTERNAL),)
 TARGETS += yosys-abc$(EXE)
+else
+CXXFLAGS += -DYOSYS_ABC_EXE=\"$(ABCEXTERNAL)\"
+endif
 endif
 
 ifeq ($(ENABLE_VERIFIC),1)

--- a/passes/techmap/abc.cc
+++ b/passes/techmap/abc.cc
@@ -29,6 +29,10 @@
 // Kahn, Arthur B. (1962), "Topological sorting of large networks", Communications of the ACM 5 (11): 558-562, doi:10.1145/368996.369025
 // http://en.wikipedia.org/wiki/Topological_sorting
 
+#ifndef YOSYS_ABC_EXE
+#define YOSYS_ABC_EXE "yosys-abc" // uses in-tree ABC by default
+#endif
+
 #define ABC_COMMAND_LIB "strash; scorr; ifraig; retime {D}; strash; dch -f; map {D}"
 #define ABC_COMMAND_CTR "strash; scorr; ifraig; retime {D}; strash; dch -f; map {D}; buffer; upsize {D}; dnsize {D}; stime -p"
 #define ABC_COMMAND_LUT "strash; scorr; ifraig; retime; strash; dch -f; if; mfs"
@@ -1173,7 +1177,7 @@ struct AbcPass : public Pass {
 		log("library to a target architecture.\n");
 		log("\n");
 		log("    -exe <command>\n");
-		log("        use the specified command name instead of \"yosys-abc\" to execute ABC.\n");
+		log("        use the specified command name instead of \"" YOSYS_ABC_EXE "\" to execute ABC.\n");
 		log("        This can e.g. be used to call a specific version of ABC or a wrapper.\n");
 		log("\n");
 		log("    -script <file>\n");
@@ -1298,7 +1302,7 @@ struct AbcPass : public Pass {
 		log_header("Executing ABC pass (technology mapping using ABC).\n");
 		log_push();
 
-		std::string exe_file = proc_self_dirname() + "yosys-abc";
+		std::string exe_file = proc_self_dirname() + YOSYS_ABC_EXE;
 		std::string script_file, liberty_file, constr_file, clk_str, delay_target;
 		bool fast_mode = false, dff_mode = false, keepff = false, cleanup = true;
 		bool show_tempdir = false;
@@ -1311,8 +1315,8 @@ struct AbcPass : public Pass {
 		enabled_gates.clear();
 
 #ifdef _WIN32
-		if (!check_file_exists(exe_file + ".exe") && check_file_exists(proc_self_dirname() + "..\\yosys-abc.exe"))
-			exe_file = proc_self_dirname() + "..\\yosys-abc";
+		if (!check_file_exists(exe_file + ".exe") && check_file_exists(proc_self_dirname() + "..\\" YOSYS_ABC_EXE ".exe"))
+			exe_file = proc_self_dirname() + "..\\" YOSYS_ABC_EXE;
 #endif
 
 		size_t argidx;


### PR DESCRIPTION
$ make ABCEXTERNAL=my-abc && make ABCEXTERNAL=my-abc install

configures yosys to use an external ABC executable instead of
building and installing the in-tree ABC copy (yosys-abc).