### PR TITLE
Fix for issue #164

### DIFF
--- a/passes/tests/test_autotb.cc
+++ b/passes/tests/test_autotb.cc
@@ -305,6 +305,7 @@ static void autotest(std::ostream &f, RTLIL::Design *design, int num_iter)
 	for (auto it = design->modules_.begin(); it != design->modules_.end(); ++it)
 		if (!it->second->get_bool_attribute("\\gentb_skip"))
 			f << stringf("\t%s;\n", idy(it->first.str(), "test").c_str());
+	f << stringf("\t$fclose(file);\n");
 	f << stringf("\t$finish;\n");
 	f << stringf("end\n\n");
 

--- a/tests/tools/autotest.sh
+++ b/tests/tools/autotest.sh
@@ -65,8 +65,8 @@ compile_and_run() {
 	if $use_modelsim; then
 		altver=$( ls -v /opt/altera/ | grep '^[0-9]' | tail -n1; )
 		/opt/altera/$altver/modelsim_ase/bin/vlib work
-		/opt/altera/$altver/modelsim_ase/bin/vlog "$@"
-		/opt/altera/$altver/modelsim_ase/bin/vsim -c -do 'run -all; exit;' testbench | grep '#OUT#' > "$output"
+		/opt/altera/$altver/modelsim_ase/bin/vlog +define+dmp_name=\"$output\" "$@"
+		/opt/altera/$altver/modelsim_ase/bin/vsim -c -do 'run -all; exit;' testbench
 	elif $use_xsim; then
 		(
 			set +x
@@ -76,8 +76,8 @@ compile_and_run() {
 			/opt/Xilinx/Vivado/$xilver/bin/xelab -R work.testbench | grep '#OUT#' > "$output"
 		)
 	else
-		iverilog -s testbench -o "$exe" "$@"
-		vvp -n "$exe" > "$output"
+		iverilog  -Ddmp_name=\"$output\" -s testbench -o "$exe" "$@" 
+		vvp -n "$exe"
 	fi
 }
 


### PR DESCRIPTION
Testbench writes output dumps instead of redirected STD to file.
No need to grep #OUT#
DUT ERROR prints don't pollute output dump.
I have tested this fix with vsim and iverilog.
**xsim needs to be fixed.** I don't have ability test how to pass defines to xsim.