### PR TITLE
Made the expansion order of hierarchy deterministic

### DIFF
--- a/passes/hierarchy/hierarchy.cc
+++ b/passes/hierarchy/hierarchy.cc
@@ -261,7 +261,7 @@ bool expand_module(RTLIL::Design *design, RTLIL::Module *module, bool flag_check
 	return did_something;
 }
 
-void hierarchy_worker(RTLIL::Design *design, std::set<RTLIL::Module*> &used, RTLIL::Module *mod, int indent)
+void hierarchy_worker(RTLIL::Design *design, std::set<RTLIL::Module*, IdString::compare_ptr_by_name<Module>> &used, RTLIL::Module *mod, int indent)
 {
 	if (used.count(mod) > 0)
 		return;
@@ -287,7 +287,7 @@ void hierarchy_worker(RTLIL::Design *design, std::set<RTLIL::Module*> &used, RTL
 
 void hierarchy_clean(RTLIL::Design *design, RTLIL::Module *top, bool purge_lib)
 {
-	std::set<RTLIL::Module*> used;
+	std::set<RTLIL::Module*, IdString::compare_ptr_by_name<Module>> used;
 	hierarchy_worker(design, used, top, 0);
 
 	std::vector<RTLIL::Module*> del_modules;
@@ -523,7 +523,7 @@ struct HierarchyPass : public Pass {
 		{
 			did_something = false;
 
-			std::set<RTLIL::Module*> used_modules;
+			std::set<RTLIL::Module*, IdString::compare_ptr_by_name<Module>> used_modules;
 			if (top_mod != NULL) {
 				log_header(design, "Analyzing design hierarchy..\n");
 				hierarchy_worker(design, used_modules, top_mod, 0);


### PR DESCRIPTION
The `hierarchy_worker` function in `passes/hierarchy/hierarchy.cc` fills a `std::set` with pointers to modules to expand.  Because it does not specify a comparison function, pointer comparison will be used, leading to undeterministic ordering in the set.  Unfortunately, expanding the modules in different orders lead to differences in the BLIF output that affects the placing and routing of arachne-pnr.  Thus, it is possible for the same design to fail to route on one system and route OK on a different system even though the versions and options of yosys and arachne-pnr are identical.

Long story short, I think that `IdString::compare_ptr_by_name` should be used here to ensure deterministic output.