### PR TITLE
Added support for SystemVerilog packages with localparam definitions

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -997,7 +997,7 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump
 			for (auto n : global_decls)
 				(*it)->children.push_back(n->clone());
 
-			for (auto n : design->packages){
+			for (auto n : design->verilog_packages){
 				for (auto o : n->children) {
 					AstNode *cloned_node = o->clone();
 					cloned_node->str = n->str + std::string("::") + cloned_node->str.substr(1);
@@ -1023,7 +1023,7 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump
 			design->add(process_module(*it, defer));
 		}
 		else if ((*it)->type == AST_PACKAGE){
-			design->packages.push_back((*it)->clone());
+			design->verilog_packages.push_back((*it)->clone());
 		}
 		else
 			global_decls.push_back(*it);

--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -151,6 +151,7 @@ std::string AST::type2str(AstNodeType type)
 	X(AST_POSEDGE)
 	X(AST_NEGEDGE)
 	X(AST_EDGE)
+	X(AST_PACKAGE)
 #undef X
 	default:
 		log_abort();
@@ -996,6 +997,14 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump
 			for (auto n : global_decls)
 				(*it)->children.push_back(n->clone());
 
+			for (auto n : design->packages){
+				for (auto o : n->children) {
+					AstNode *cloned_node = o->clone();
+					cloned_node->str = n->str + std::string("::") + cloned_node->str.substr(1);
+					(*it)->children.push_back(cloned_node);
+				}
+			}
+
 			if (flag_icells && (*it)->str.substr(0, 2) == "\\$")
 				(*it)->str = (*it)->str.substr(1);
 
@@ -1012,6 +1021,9 @@ void AST::process(RTLIL::Design *design, AstNode *ast, bool dump_ast1, bool dump
 			}
 
 			design->add(process_module(*it, defer));
+		}
+		else if ((*it)->type == AST_PACKAGE){
+			design->packages.push_back((*it)->clone());
 		}
 		else
 			global_decls.push_back(*it);

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -137,7 +137,9 @@ namespace AST
 
 		AST_POSEDGE,
 		AST_NEGEDGE,
-		AST_EDGE
+		AST_EDGE,
+
+		AST_PACKAGE
 	};
 
 	// convert an node type to a string (e.g. for debug output)

--- a/frontends/ast/genrtlil.cc
+++ b/frontends/ast/genrtlil.cc
@@ -806,6 +806,7 @@ RTLIL::SigSpec AstNode::genRTLIL(int width_hint, bool sign_hint)
 	case AST_GENBLOCK:
 	case AST_GENIF:
 	case AST_GENCASE:
+	case AST_PACKAGE:
 		break;
 
 	// remember the parameter, needed for example in techmap

--- a/frontends/verilog/verilog_lexer.l
+++ b/frontends/verilog/verilog_lexer.l
@@ -141,6 +141,8 @@ YOSYS_NAMESPACE_END
 "endfunction"  { return TOK_ENDFUNCTION; }
 "task"         { return TOK_TASK; }
 "endtask"      { return TOK_ENDTASK; }
+"package"      { SV_KEYWORD(TOK_PACKAGE); }
+"endpackage"   { SV_KEYWORD(TOK_ENDPACKAGE); }
 "parameter"    { return TOK_PARAMETER; }
 "localparam"   { return TOK_LOCALPARAM; }
 "defparam"     { return TOK_DEFPARAM; }
@@ -350,6 +352,8 @@ import[ \t\r\n]+\"(DPI|DPI-C)\"[ \t\r\n]+function[ \t\r\n]+ {
 ">>"  { return OP_SHR; }
 "<<<" { return OP_SSHL; }
 ">>>" { return OP_SSHR; }
+
+"::"  { SV_KEYWORD(TOK_PACKAGESEP); }
 
 "+:" { return TOK_POS_INDEXED; }
 "-:" { return TOK_NEG_INDEXED; }

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -304,6 +304,8 @@ RTLIL::Design::~Design()
 {
 	for (auto it = modules_.begin(); it != modules_.end(); ++it)
 		delete it->second;
+	for (auto n : packages)
+		delete n;
 }
 
 RTLIL::ObjRange<RTLIL::Module*> RTLIL::Design::modules()

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -304,7 +304,7 @@ RTLIL::Design::~Design()
 {
 	for (auto it = modules_.begin(); it != modules_.end(); ++it)
 		delete it->second;
-	for (auto n : packages)
+	for (auto n : verilog_packages)
 		delete n;
 }
 

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -18,6 +18,7 @@
  */
 
 #include "kernel/yosys.h"
+#include "frontends/ast/ast.h"
 
 #ifndef RTLIL_H
 #define RTLIL_H
@@ -792,6 +793,7 @@ struct RTLIL::Design
 
 	int refcount_modules_;
 	dict<RTLIL::IdString, RTLIL::Module*> modules_;
+	std::vector<AST::AstNode*> packages;
 
 	std::vector<RTLIL::Selection> selection_stack;
 	dict<RTLIL::IdString, RTLIL::Selection> selection_vars;

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -18,7 +18,6 @@
  */
 
 #include "kernel/yosys.h"
-#include "frontends/ast/ast.h"
 
 #ifndef RTLIL_H
 #define RTLIL_H
@@ -793,7 +792,7 @@ struct RTLIL::Design
 
 	int refcount_modules_;
 	dict<RTLIL::IdString, RTLIL::Module*> modules_;
-	std::vector<AST::AstNode*> packages;
+	std::vector<AST::AstNode*> verilog_packages;
 
 	std::vector<RTLIL::Selection> selection_stack;
 	dict<RTLIL::IdString, RTLIL::Selection> selection_vars;


### PR DESCRIPTION
Hi Clifford,

I've put together some code which enables having packages in separate files with localparams. This is a pretty common thing to do in SystemVerilog. The behaviour seems to be correct after the changes. I don't expect that you accept the pull request right away, but I'm looking for feedback.

At first I made a global vector with all packages, but this did not fit well with the "Design" concept, so therefore I had to add a package-vector as a member of the Design struct. This requires including "ast.h" in rtlil.h

It is not very efficient to always copy all members of every package to every module, but to change this, I wanted to (in simplify) check if the identifier-name contains "::", and in that case include all members of the corresponding packages in current_scope. This would require defining some global variable for having access to the package-vector in simplify, or I would have to add another argument to the function argument list of simplify. I guess you would prefer global variables?

Best regards,
Ruben