### PR TITLE
Add MSYS2-compatible build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CONFIG := clang
 # CONFIG := gcc-4.8
 # CONFIG := emcc
 # CONFIG := mxe
+CONFIG := msys2
 
 # features (the more the better)
 ENABLE_TCL := 1
@@ -172,8 +173,19 @@ ABCMKARGS += ARCHFLAGS="-DSIZEOF_VOID_P=4 -DSIZEOF_LONG=4 -DSIZEOF_INT=4 -DWIN32
 ABCMKARGS += LIBS="lib/x86/pthreadVC2.lib -s" ABC_USE_NO_READLINE=1 CC="$(CXX)" CXX="$(CXX)"
 EXE = .exe
 
+else ifeq ($(CONFIG),msys2)
+CXX = i686-w64-mingw32-gcc
+LD = i686-w64-mingw32-gcc
+CXXFLAGS += -std=c++11 -Os -D_POSIX_SOURCE -DYOSYS_WIN32_UNIX_DIR
+CXXFLAGS := $(filter-out -fPIC,$(CXXFLAGS))
+LDFLAGS := $(filter-out -rdynamic,$(LDFLAGS)) -s
+LDLIBS := $(filter-out -lrt,$(LDLIBS))
+ABCMKARGS += ARCHFLAGS="-DSIZEOF_VOID_P=4 -DSIZEOF_LONG=4 -DSIZEOF_INT=4 -DWIN32_NO_DLL -DHAVE_STRUCT_TIMESPEC -x c++ -fpermissive -w"
+ABCMKARGS += LIBS="lib/x86/pthreadVC2.lib -s" ABC_USE_NO_READLINE=0 CC="$(CXX)" CXX="$(CXX)"
+EXE = .exe
+
 else ifneq ($(CONFIG),none)
-$(error Invalid CONFIG setting '$(CONFIG)'. Valid values: clang, gcc, gcc-4.8, emcc, none)
+$(error Invalid CONFIG setting '$(CONFIG)'. Valid values: clang, gcc, gcc-4.8, emcc, mxe, msys2)
 endif
 
 ifeq ($(ENABLE_LIBYOSYS),1)
@@ -514,6 +526,9 @@ config-mxe: clean
 	echo 'ENABLE_PLUGINS := 0' >> Makefile.conf
 	echo 'ENABLE_READLINE := 0' >> Makefile.conf
 
+config-msys2: clean
+	echo 'CONFIG := msys2' > Makefile.conf
+
 config-gprof: clean
 	echo 'CONFIG := gcc' > Makefile.conf
 	echo 'ENABLE_GPROF := 1' >> Makefile.conf
@@ -536,4 +551,3 @@ echo-git-rev:
 
 .PHONY: all top-all abc test install install-abc manual clean mrproper qtcreator
 .PHONY: config-clean config-clang config-gcc config-gcc-4.8 config-gprof config-sudo
-

--- a/kernel/yosys.cc
+++ b/kernel/yosys.cc
@@ -687,7 +687,7 @@ std::string proc_share_dirname()
 std::string proc_share_dirname()
 {
 	std::string proc_self_path = proc_self_dirname();
-#  ifdef _WIN32
+#  if defined(_WIN32) && !defined(YOSYS_WIN32_UNIX_DIR)
 	std::string proc_share_path = proc_self_path + "share\\";
 	if (check_file_exists(proc_share_path, true))
 		return proc_share_path;
@@ -1130,4 +1130,3 @@ struct ScriptCmdPass : public Pass {
 } ScriptCmdPass;
 
 YOSYS_NAMESPACE_END
-


### PR DESCRIPTION
Both aranche-pnr and Icestorm allow one to link against libraries and install into the MSYS2 hierarchy without modification by just running the `gcc` config. For various reasons, this does not work with yosys. Because I would prefer to keep programs compiled with gcc under a single hierarchy, like a Unix installation, and because I may need to make further changes to yosys (openfpga work), I added a target that allows MSYS compilation.

As of this commit, this now means it is possible to successfully build a native yosys on Windows. There is currently a minor issue when building any target:

```
couldn't read file "/proc/17844/fd/63": no such file or directory
couldn't read file "/proc/17764/fd/63": no such file or directory
```

While MSYS2 does come with a `/proc` file system, it doesn't appear to follow conventions the build systems expects. I haven't been able to determine what causes this. Grepping the source tree for `/proc/` returns a few PID-specific directories in proc, but nothing with an `fd` subdirectory. That said, it appears to be harmless.
