### PR TITLE
Add some useful flexibility to build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ OBJS = kernel/version_$(GIT_REV).o
 # delete your work on ABC..
 ABCREV = a86455b00da5
 ABCPULL = 1
+ABCURL ?= https://bitbucket.org/alanmi/abc
 ABCMKARGS = CC="$(CXX)" CXX="$(CXX)"
 
 # set ABCEXTERNAL = <abc-command> to use an external ABC instance
@@ -387,8 +388,8 @@ ifneq ($(ABCREV),default)
 	fi
 	$(Q) if test "`cd abc 2> /dev/null && hg identify | cut -f1 -d' '`" != "$(ABCREV)"; then \
 		test $(ABCPULL) -ne 0 || { echo 'REEBE: NOP abg hc gb qngr naq NOPCHYY frg gb 0 va Znxrsvyr!' | tr 'A-Za-z' 'N-ZA-Mn-za-m'; exit 1; }; \
-		echo "Pulling ABC from bitbucket.org:"; set -x; \
-		test -d abc || hg clone https://bitbucket.org/alanmi/abc abc; \
+		echo "Pulling ABC from $(ABCURL):"; set -x; \
+		test -d abc || hg clone $(ABCURL) abc; \
 		cd abc && $(MAKE) DEP= clean && hg pull && hg update -r $(ABCREV); \
 	fi
 endif

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ else
 	LDLIBS += -lrt
 endif
 
-YOSYS_VER := 0.6+$(shell test -d .git && { git log --author=clifford@clifford.at --oneline 5869d26da021.. | wc -l; })
+YOSYS_VER := 0.6+$(shell test -e .git && { git log --author=clifford@clifford.at --oneline 5869d26da021.. | wc -l; })
 GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short HEAD 2> /dev/null || echo UNKNOWN)
 OBJS = kernel/version_$(GIT_REV).o
 


### PR DESCRIPTION
These two commits add some flexibility to the build process without compromising the default operation.

Adding a variable for the URL of the ABC Mercurial repository allows a user to override the default location in the case where the user is privately mirroring the ABC repository.

The second commit allows yosys to be a submodule. Currently, if yosys is a submodule, the YOSYS_VER variable is not properly set. More specifically, the number of commits since the last tag is left off due to the "test" command returning false.