### PR TITLE
cmd 'show', help, add info to generate 'dot' file

### DIFF
--- a/passes/cmds/show.cc
+++ b/passes/cmds/show.cc
@@ -584,6 +584,7 @@ struct ShowPass : public Pass {
 		log("    -format <format>\n");
 		log("        Generate a graphics file in the specified format.\n");
 		log("        Usually <format> is 'svg' or 'ps'.\n");
+		log("        To generate graph description instead of image, 'dot' can be used.\n");
 		log("\n");
 		log("    -lib <verilog_or_ilang_file>\n");
 		log("        Use the specified library file for determining whether cell ports are\n");


### PR DESCRIPTION
I discover [here](https://www.reddit.com/r/yosys/comments/2w9uvn/newbie_howto_yosys_on_windows/#thing_t1_cop8q1p) that there is a proper way to generate dot graph description instead of image (the graph->image process can take a long time). Before found this I used `-viewer echo` but the right way is `-format dot`. I propose to add this information in the help message of the `show` command