### PR TITLE
Added  a new configuration variable GIT_REV_WHERE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ else
 SEEDOPT=""
 endif
 
-test-all: $(TARGETS) $(EXTRA_TARGETS)
+test: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/simple && bash run-test.sh $(SEEDOPT)
 	+cd tests/hana && bash run-test.sh $(SEEDOPT)
 	+cd tests/asicworld && bash run-test.sh $(SEEDOPT)
@@ -558,6 +558,6 @@ echo-git-rev:
 -include kernel/*.d
 -include techlibs/*/*.d
 
-.PHONY: all top-all abc test-all install install-abc manual clean mrproper qtcreator
+.PHONY: all top-all abc test install install-abc manual clean mrproper qtcreator
 .PHONY: config-clean config-clang config-gcc config-gcc-4.8 config-gprof config-sudo
 

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,9 @@ else
 	LDLIBS += -lrt
 endif
 
+GIT_REV_WHERE ?= HEAD
 YOSYS_VER := 0.6+$(shell test -e .git && { git log --author=clifford@clifford.at --oneline 5869d26da021.. | wc -l; })
-GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short HEAD 2> /dev/null || echo UNKNOWN)
+GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short $(GIT_REV_WHERE) 2> /dev/null || echo UNKNOWN)
 OBJS = kernel/version_$(GIT_REV).o
 
 # set 'ABCREV = default' to use abc/ as it is

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,8 @@ else
 	LDLIBS += -lrt
 endif
 
-GIT_REV_WHERE ?= HEAD
 YOSYS_VER := 0.6+$(shell test -e .git && { git log --author=clifford@clifford.at --oneline 5869d26da021.. | wc -l; })
-GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short $(GIT_REV_WHERE) 2> /dev/null || echo UNKNOWN)
+GIT_REV ?= $(shell cd $(YOSYS_SRC) && git rev-parse --short HEAD 2> /dev/null || echo UNKNOWN)
 OBJS = kernel/version_$(GIT_REV).o
 
 # set 'ABCREV = default' to use abc/ as it is


### PR DESCRIPTION
It determines from where we get the gits SHA1 value. By default is HEAD,
suitable for Clifford, but for Debian we can define it as upstream/master