### PR TITLE
Allow to overwrite ABCEXTERNAL from the environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ ABCMKARGS = CC="$(CXX)" CXX="$(CXX)"
 
 # set ABCEXTERNAL = <abc-command> to use an external ABC instance
 # Note: The in-tree ABC (yosys-abc) will not be installed when ABCEXTERNAL is set.
-ABCEXTERNAL =
+ABCEXTERNAL ?=
 
 define newline
 

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,8 @@ else
 	LDLIBS += -lrt
 endif
 
-GIT_REV_WHERE ?= HEAD
 YOSYS_VER := 0.6+$(shell test -e .git && { git log --author=clifford@clifford.at --oneline 5869d26da021.. | wc -l; })
-GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short $(GIT_REV_WHERE) 2> /dev/null || echo UNKNOWN)
+GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short HEAD 2> /dev/null || echo UNKNOWN)
 OBJS = kernel/version_$(GIT_REV).o
 
 # set 'ABCREV = default' to use abc/ as it is
@@ -411,7 +410,7 @@ else
 SEEDOPT=""
 endif
 
-test-all: $(TARGETS) $(EXTRA_TARGETS)
+test: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/simple && bash run-test.sh $(SEEDOPT)
 	+cd tests/hana && bash run-test.sh $(SEEDOPT)
 	+cd tests/asicworld && bash run-test.sh $(SEEDOPT)
@@ -558,6 +557,6 @@ echo-git-rev:
 -include kernel/*.d
 -include techlibs/*/*.d
 
-.PHONY: all top-all abc test-all install install-abc manual clean mrproper qtcreator
+.PHONY: all top-all abc test install install-abc manual clean mrproper qtcreator
 .PHONY: config-clean config-clang config-gcc config-gcc-4.8 config-gprof config-sudo
 

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,9 @@ else
 	LDLIBS += -lrt
 endif
 
+GIT_REV_WHERE ?= HEAD
 YOSYS_VER := 0.6+$(shell test -e .git && { git log --author=clifford@clifford.at --oneline 5869d26da021.. | wc -l; })
-GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short HEAD 2> /dev/null || echo UNKNOWN)
+GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short $(GIT_REV_WHERE) 2> /dev/null || echo UNKNOWN)
 OBJS = kernel/version_$(GIT_REV).o
 
 # set 'ABCREV = default' to use abc/ as it is

--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ else
 SEEDOPT=""
 endif
 
-test: $(TARGETS) $(EXTRA_TARGETS)
+test-all: $(TARGETS) $(EXTRA_TARGETS)
 	+cd tests/simple && bash run-test.sh $(SEEDOPT)
 	+cd tests/hana && bash run-test.sh $(SEEDOPT)
 	+cd tests/asicworld && bash run-test.sh $(SEEDOPT)
@@ -558,6 +558,6 @@ echo-git-rev:
 -include kernel/*.d
 -include techlibs/*/*.d
 
-.PHONY: all top-all abc test install install-abc manual clean mrproper qtcreator
+.PHONY: all top-all abc test-all install install-abc manual clean mrproper qtcreator
 .PHONY: config-clean config-clang config-gcc config-gcc-4.8 config-gprof config-sudo
 


### PR DESCRIPTION
In this way Debian scripts can define it as berkeley-abc from the shell.