### PR TITLE
Added optional flag for linking curses with readline.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ ENABLE_LIBYOSYS := 0
 # other configuration flags
 ENABLE_GPROF := 0
 ENABLE_NDEBUG := 0
+LINK_CURSES := 0
 
 # clang sanitizers
 SANITIZER =
@@ -196,6 +197,10 @@ endif
 ifeq ($(ENABLE_READLINE),1)
 CXXFLAGS += -DYOSYS_ENABLE_READLINE
 LDLIBS += -lreadline
+ifeq ($(LINK_CURSES),1)
+LDLIBS += -lcurses
+ABCMKARGS += "ABC_READLINE_LIBRARIES=-lcurses -lreadline"
+endif
 ifeq ($(CONFIG),mxe)
 LDLIBS += -lpdcurses
 endif


### PR DESCRIPTION
On some Linux systems, -lcurses is required in addition to -lreadline. LINK_CURSES adds this (optionally) both to yosys and abc. This is a problem that has been recognized by ABC as well on their [bitbucket page](https://bitbucket.org/alanmi/abc).

I'm not sure if this is the best way to go about adding it, but I think it's a good start.