### PR TITLE
Use Homebrew only if installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,8 @@ BREW_PREFIX := $(shell brew --prefix)/opt
 CXXFLAGS += -I$(BREW_PREFIX)/readline/include
 LDFLAGS += -L$(BREW_PREFIX)/readline/lib
 
-export PKG_CONFIG_PATH := $(BREW_PREFIX)/libffi/lib/pkgconfig:$(PKG_CONFIG_PATH)
+PKG_CONFIG_PATH := $(BREW_PREFIX)/libffi/lib/pkgconfig:$(PKG_CONFIG_PATH)
+
 export PATH := $(BREW_PREFIX)/bison/bin:$(BREW_PREFIX)/gettext/bin:$(BREW_PREFIX)/flex/bin:$(PATH)
 endif
 
@@ -81,7 +82,8 @@ PORT_PREFIX := $(patsubst %/bin/port,%,$(shell which port))
 CXXFLAGS += -I$(PORT_PREFIX)/include
 LDFLAGS += -L$(PORT_PREFIX)/lib
 
-export PKG_CONFIG_PATH := $(PORT_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+PKG_CONFIG_PATH := $(PORT_PREFIX)/lib/pkgconfig:$(PKG_CONFIG_PATH)
+
 export PATH := $(PORT_PREFIX)/bin:$(PATH)
 endif
 
@@ -224,8 +226,8 @@ endif
 endif
 
 ifeq ($(ENABLE_PLUGINS),1)
-CXXFLAGS += -DYOSYS_ENABLE_PLUGINS $(shell $(PKG_CONFIG) --silence-errors --cflags libffi)
-LDLIBS += $(shell $(PKG_CONFIG) --silence-errors --libs libffi || echo -lffi) -ldl
+CXXFLAGS += -DYOSYS_ENABLE_PLUGINS $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --cflags libffi)
+LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs libffi || echo -lffi) -ldl
 endif
 
 ifeq ($(ENABLE_TCL),1)

--- a/Makefile
+++ b/Makefile
@@ -62,15 +62,17 @@ SED = sed
 BISON = bison
 
 ifeq (Darwin,$(findstring Darwin,$(shell uname)))
+	BREW := $(shell command -v brew 2> /dev/null)
+	ifdef BREW
+		export PKG_CONFIG_PATH = $(shell $(BREW) list libffi | grep pkgconfig | xargs dirname)
+		BISON = $(shell $(BREW) list bison | grep -m1 "bin/bison")
+	endif
 	# add macports/homebrew include and library path to search directories, don't use '-rdynamic' and '-lrt':
 	CXXFLAGS += -I/opt/local/include -I/usr/local/opt/readline/include
 	LDFLAGS += -L/opt/local/lib -L/usr/local/opt/readline/lib
-	# add homebrew's libffi include and library path
-	CXXFLAGS += $(shell PKG_CONFIG_PATH=$$(brew list libffi | grep pkgconfig | xargs dirname) pkg-config --silence-errors --cflags libffi)
-	LDFLAGS += $(shell PKG_CONFIG_PATH=$$(brew list libffi | grep pkgconfig | xargs dirname) pkg-config --silence-errors --libs libffi)
-	# use bison installed by homebrew if available
-	BISON = $(shell (brew list bison | grep -m1 "bin/bison") || echo bison)
-	SED = sed
+	# add macports/homebrew's libffi include and library path
+	CXXFLAGS += $(shell pkg-config --silence-errors --cflags libffi)
+	LDFLAGS += $(shell pkg-config --silence-errors --libs libffi)
 else
 	LDFLAGS += -rdynamic
 	LDLIBS += -lrt

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ CXXFLAGS += -I$(BREW_PREFIX)/readline/include
 LDFLAGS += -L$(BREW_PREFIX)/readline/lib
 
 PKG_CONFIG_PATH := $(BREW_PREFIX)/libffi/lib/pkgconfig:$(PKG_CONFIG_PATH)
+PKG_CONFIG_PATH := $(BREW_PREFIX)/tcl-tk/lib/pkgconfig:$(PKG_CONFIG_PATH)
 
 export PATH := $(BREW_PREFIX)/bison/bin:$(BREW_PREFIX)/gettext/bin:$(BREW_PREFIX)/flex/bin:$(PATH)
 
@@ -225,15 +226,16 @@ endif
 endif
 
 ifeq ($(ENABLE_PLUGINS),1)
-CXXFLAGS += -DYOSYS_ENABLE_PLUGINS $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --cflags libffi)
+CXXFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --cflags libffi) -DYOSYS_ENABLE_PLUGINS
 LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs libffi || echo -lffi) -ldl
 endif
 
 ifeq ($(ENABLE_TCL),1)
 TCL_VERSION ?= tcl$(shell bash -c "tclsh <(echo 'puts [info tclversion]')")
 TCL_INCLUDE ?= /usr/include/$(TCL_VERSION)
-CXXFLAGS += -I$(TCL_INCLUDE) -DYOSYS_ENABLE_TCL
-LDLIBS += -l$(TCL_VERSION)
+
+CXXFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --cflags tcl || echo -I$(TCL_INCLUDE)) -DYOSYS_ENABLE_TCL
+LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs tcl || echo -l$(TCL_VERSION))
 endif
 
 ifeq ($(ENABLE_GPROF),1)

--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,9 @@ LDFLAGS += -L$(BREW_PREFIX)/readline/lib
 PKG_CONFIG_PATH := $(BREW_PREFIX)/libffi/lib/pkgconfig:$(PKG_CONFIG_PATH)
 
 export PATH := $(BREW_PREFIX)/bison/bin:$(BREW_PREFIX)/gettext/bin:$(BREW_PREFIX)/flex/bin:$(PATH)
-endif
 
 # macports search paths
-ifneq ($(shell which port),)
+else ifneq ($(shell which port),)
 PORT_PREFIX := $(patsubst %/bin/port,%,$(shell which port))
 
 CXXFLAGS += -I$(PORT_PREFIX)/include

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ CXXFLAGS += -Wall -Wextra -ggdb -I. -I"$(YOSYS_SRC)" -MD -D_YOSYS_ -fPIC -I$(PRE
 LDFLAGS += -L$(LIBDIR)
 LDLIBS = -lstdc++ -lm
 
-PKG_CONFIG = pkg-config
-SED = sed
-BISON = bison
+PKG_CONFIG ?= pkg-config
+SED ?= sed
+BISON ?= bison
 
 ifeq (Darwin,$(findstring Darwin,$(shell uname)))
 	BREW := $(shell command -v brew 2> /dev/null)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Similarily, on Mac OS X MacPorts or Homebrew can be used to install dependencies
 	$ brew install bison flex gawk libffi \
 		git mercurial graphviz pkg-config python3
 	$ sudo port install bison flex readline gawk libffi \ 
-		git mercurial graphviz pkg-config python3
+		git mercurial graphviz pkgconfig python36
 
 There are also pre-compiled Yosys binary packages for Ubuntu and Win32 as well
 as a source distribution for Visual Studio. Visit the Yosys download page for

--- a/README.md
+++ b/README.md
@@ -40,20 +40,27 @@ Web Site
 More information and documentation can be found on the Yosys web site:
 http://www.clifford.at/yosys/
 
-
-Getting Started
-===============
+Setup
+======
 
 You need a C++ compiler with C++11 support (up-to-date CLANG or GCC is
 recommended) and some standard tools such as GNU Flex, GNU Bison, and GNU Make.
 TCL, readline and libffi are optional (see ENABLE_* settings in Makefile).
 Xdot (graphviz) is used by the ``show`` command in yosys to display schematics.
+
 For example on Ubuntu Linux 16.04 LTS the following commands will install all
 prerequisites for building yosys:
 
 	$ sudo apt-get install build-essential clang bison flex \
 		libreadline-dev gawk tcl-dev libffi-dev git mercurial \
 		graphviz xdot pkg-config python3
+
+Similarily, on Mac OS X MacPorts or Homebrew can be used to install dependencies:
+
+	$ brew install bison flex gawk libffi \
+		git mercurial graphviz pkg-config python3
+	$ sudo port install bison flex readline gawk libffi \ 
+		git mercurial graphviz pkg-config python3
 
 There are also pre-compiled Yosys binary packages for Ubuntu and Win32 as well
 as a source distribution for Visual Studio. Visit the Yosys download page for
@@ -79,6 +86,9 @@ To build Yosys simply type 'make' in this directory.
 
 Note that this also downloads, builds and installs ABC (using yosys-abc
 as executable name).
+
+Getting Started
+===============
 
 Yosys can be used with the interactive command shell, with
 synthesis scripts or with command line arguments. Let's perform

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Similarily, on Mac OS X MacPorts or Homebrew can be used to install dependencies
 
 	$ brew install bison flex gawk libffi \
 		git mercurial graphviz pkg-config python3
-	$ sudo port install bison flex readline gawk libffi \ 
+	$ sudo port install bison flex readline gawk libffi \
 		git mercurial graphviz pkgconfig python36
 
 There are also pre-compiled Yosys binary packages for Ubuntu and Win32 as well


### PR DESCRIPTION
I use MacPorts on my machine which gives me a lot of "command not found: brew" warnings during compilation.

This is because `brew` is called everytime for generating the compiler flags.
`brew`should be called only once. And only of available..