### PR TITLE
Add missing slashes in paths for make uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,7 +478,7 @@ ifeq ($(ENABLE_LIBYOSYS),1)
 endif
 
 uninstall:
-	$(INSTALL_SUDO) rm -vf $(addprefix $(DESTDIR)$(BINDIR),$(notdir $(TARGETS)))
+	$(INSTALL_SUDO) rm -vf $(addprefix $(DESTDIR)$(BINDIR)/,$(notdir $(TARGETS)))
 	$(INSTALL_SUDO) rm -rvf $(DESTDIR)$(DATDIR)
 ifeq ($(ENABLE_LIBYOSYS),1)
 	$(INSTALL_SUDO) rm -vf $(DESTDIR)$(LIBDIR)/libyosys.so


### PR DESCRIPTION
Running make uninstall used to fail to remove binaries:
```shell
rm -vf /usr/local/binyosys /usr/local/binyosys-config #...etc
```

Fix Makefile so that it runs a command like this:
```shell
rm -vf /usr/local/bin/yosys /usr/local/bin/yosys-config #...etc
```