### PR TITLE
Yosys 0.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,20 @@ List of major changes and improvements between releases
 =======================================================
 
 
+Yosys 0.7 .. Yosys 0.8
+----------------------
+
+ * Various
+     - Added Contributor dh73, Code of Conduct.
+     - Added initial version of metacommand "synth_intel".
+     - Improved write_verilog command to produce VQM netlist for Quartus Prime.
+     - Added support for MAX10 FPGA family synthesis.
+     - Added support for Cyclone IV family synthesis.
+     - Added example of implementation for DE2i-150 board.
+     - Added example of implementation for MAX10 development kit.
+     - Added LFSR example from Asic World.
+
+
 Yosys 0.6 .. Yosys 0.7
 ----------------------
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ LDFLAGS += -rdynamic
 LDLIBS += -lrt
 endif
 
-YOSYS_VER := 0.7+$(shell cd $(YOSYS_SRC) && test -e .git && { git log --author=clifford@clifford.at --oneline 61f6811.. | wc -l; })
+YOSYS_VER := 0.8+$(shell cd $(YOSYS_SRC) && test -e .git && { git log --author=clifford@clifford.at --oneline 61f6811.. | wc -l; })
 GIT_REV := $(shell cd $(YOSYS_SRC) && git rev-parse --short HEAD 2> /dev/null || echo UNKNOWN)
 OBJS = kernel/version_$(GIT_REV).o
 

--- a/examples/intel/DE2i-150/quartus_compile/de2i_150_golden_top.qpf
+++ b/examples/intel/DE2i-150/quartus_compile/de2i_150_golden_top.qpf
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------- #
+#
+# Copyright (C) 2017  Intel Corporation. All rights reserved.
+# Your use of Intel Corporation's design tools, logic functions 
+# and other software and tools, and its AMPP partner logic 
+# functions, and any output files from any of the foregoing 
+# (including device programming or simulation files), and any 
+# associated documentation or information are expressly subject 
+# to the terms and conditions of the Intel Program License 
+# Subscription Agreement, the Intel Quartus Prime License Agreement,
+# the Intel MegaCore Function License Agreement, or other 
+# applicable license agreement, including, without limitation, 
+# that your use is for the sole purpose of programming logic 
+# devices manufactured by Intel and sold by Intel or its 
+# authorized distributors.  Please refer to the applicable 
+# agreement for further details.
+#
+# -------------------------------------------------------------------------- #
+#
+# Quartus Prime
+# Version 16.1.2 Build 203 01/18/2017 SJ Standard Edition
+# Date created = 00:23:45  April 02, 2017
+#
+# -------------------------------------------------------------------------- #
+
+QUARTUS_VERSION = "16.1"
+DATE = "00:23:45  April 02, 2017"
+
+# Revisions
+
+PROJECT_REVISION = "de2i_150_golden_top"

--- a/examples/intel/DE2i-150/quartus_compile/de2i_150_golden_top.qsf
+++ b/examples/intel/DE2i-150/quartus_compile/de2i_150_golden_top.qsf
@@ -1,0 +1,1117 @@
+set_global_assignment -name FAMILY "Cyclone IV GX"
+set_global_assignment -name DEVICE EP4CGX150DF31C7
+set_global_assignment -name TOP_LEVEL_ENTITY "top"
+set_global_assignment -name ORIGINAL_QUARTUS_VERSION 11.1
+set_global_assignment -name LAST_QUARTUS_VERSION "16.1.2 Standard Edition"
+set_global_assignment -name PROJECT_CREATION_TIME_DATE "WED JUN 27 19:19:53 2012"
+set_global_assignment -name DEVICE_FILTER_PACKAGE FBGA
+
+
+#============================================================
+# CLOCK2
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to CLOCK2_50
+
+#============================================================
+# CLOCK3
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to CLOCK3_50
+
+#============================================================
+# CLOCK
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to CLOCK_50
+
+#============================================================
+# DRAM
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_BA[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_BA[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_CAS_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_CKE
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_CLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_CS_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[16]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[17]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[18]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[19]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[20]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[21]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[22]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[23]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[24]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[25]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[26]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[27]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[28]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[29]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[30]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[31]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQM[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQM[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQM[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQM[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_RAS_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_WE_N
+
+#============================================================
+# EEP
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to EEP_I2C_SCLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to EEP_I2C_SDAT
+
+#============================================================
+# ENET
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_GTX_CLK
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_INT_N
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_LINK100
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_MDC
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_MDIO
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RST_N
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_CLK
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_COL
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_CRS
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_DATA[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_DATA[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_DATA[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_DATA[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_DV
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_ER
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_CLK
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_DATA[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_DATA[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_DATA[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_DATA[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_EN
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_ER
+
+#============================================================
+# FAN
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to FAN_CTRL
+
+#============================================================
+# FLASH
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_RESET_N
+
+#============================================================
+# FS
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[16]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[17]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[18]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[19]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[20]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[21]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[22]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[23]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[24]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[25]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[26]
+
+#============================================================
+# FL
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_CE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_OE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_RY
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_WE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_WP_N
+
+#============================================================
+# FS
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[16]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[17]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[18]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[19]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[20]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[21]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[22]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[23]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[24]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[25]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[26]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[27]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[28]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[29]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[30]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[31]
+
+#============================================================
+# GPIO
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[16]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[17]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[18]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[19]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[20]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[21]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[22]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[23]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[24]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[25]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[26]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[27]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[28]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[29]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[30]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[31]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[32]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[33]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[34]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[35]
+
+#============================================================
+# G
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to G_SENSOR_INT1
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to G_SENSOR_SCLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to G_SENSOR_SDAT
+
+#============================================================
+# HEX0
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[6]
+
+#============================================================
+# HEX1
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[6]
+
+#============================================================
+# HEX2
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[6]
+
+#============================================================
+# HEX3
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[6]
+
+#============================================================
+# HEX4
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[6]
+
+#============================================================
+# HEX5
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[6]
+
+#============================================================
+# HEX6
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[6]
+
+#============================================================
+# HEX7
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[6]
+
+#============================================================
+# HSMC
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKIN0
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKIN_N1
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKIN_N2
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKIN_P1
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKIN_P2
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKOUT0
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKOUT_N1
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKOUT_N2
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKOUT_P1
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKOUT_P2
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_D[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_D[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_D[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_D[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_I2C_SCLK
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_I2C_SDAT
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[16]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[16]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[16]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[16]
+
+#============================================================
+# I2C
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to I2C_SCLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to I2C_SDAT
+
+#============================================================
+# IRDA
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to IRDA_RXD
+
+#============================================================
+# KEY
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to KEY[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to KEY[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to KEY[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to KEY[3]
+
+#============================================================
+# LCD
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_EN
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LCD_ON
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_RS
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_RW
+
+#============================================================
+# LEDG
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[8]
+
+#============================================================
+# LEDR
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[16]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[17]
+
+#============================================================
+# PCIE
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to PCIE_PERST_N
+set_instance_assignment -name IO_STANDARD HCSL -to PCIE_REFCLK_P
+set_instance_assignment -name IO_STANDARD "1.5-V PCML" -to PCIE_RX_P[0]
+set_instance_assignment -name IO_STANDARD "1.5-V PCML" -to PCIE_RX_P[1]
+set_instance_assignment -name IO_STANDARD "1.5-V PCML" -to PCIE_TX_P[0]
+set_instance_assignment -name IO_STANDARD "1.5-V PCML" -to PCIE_TX_P[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to PCIE_WAKE_N
+
+#============================================================
+# SD
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_CLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_CMD
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_DAT[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_DAT[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_DAT[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_DAT[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_WP_N
+
+#============================================================
+# SMA
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SMA_CLKIN
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SMA_CLKOUT
+
+#============================================================
+# SSRAM0
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM0_CE_N
+
+#============================================================
+# SSRAM1
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM1_CE_N
+
+#============================================================
+# SSRAM
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_ADSC_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_ADSP_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_ADV_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_BE[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_BE[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_BE[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_BE[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_CLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_GW_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_OE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_WE_N
+
+#============================================================
+# SW
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[16]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[17]
+
+#============================================================
+# TD
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_CLK27
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_HS
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_RESET_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_VS
+
+#============================================================
+# UART
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to UART_CTS
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to UART_RTS
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to UART_RXD
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to UART_TXD
+
+#============================================================
+# VGA
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_BLANK_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_CLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_HS
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_SYNC_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_VS
+
+#============================================================
+# End of pin assignments by Terasic System Builder
+#============================================================
+
+
+
+set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION "USE AS REGULAR IO"
+set_location_assignment PIN_A15 -to CLOCK2_50
+set_location_assignment PIN_V11 -to CLOCK3_50
+set_location_assignment PIN_AJ16 -to CLOCK_50
+set_location_assignment PIN_AG7 -to DRAM_ADDR[0]
+set_location_assignment PIN_AJ7 -to DRAM_ADDR[1]
+set_location_assignment PIN_AG8 -to DRAM_ADDR[2]
+set_location_assignment PIN_AH8 -to DRAM_ADDR[3]
+set_location_assignment PIN_AE16 -to DRAM_ADDR[4]
+set_location_assignment PIN_AF16 -to DRAM_ADDR[5]
+set_location_assignment PIN_AE14 -to DRAM_ADDR[6]
+set_location_assignment PIN_AE15 -to DRAM_ADDR[7]
+set_location_assignment PIN_AE13 -to DRAM_ADDR[8]
+set_location_assignment PIN_AE12 -to DRAM_ADDR[9]
+set_location_assignment PIN_AH6 -to DRAM_ADDR[10]
+set_location_assignment PIN_AE11 -to DRAM_ADDR[11]
+set_location_assignment PIN_AE10 -to DRAM_ADDR[12]
+set_location_assignment PIN_AH5 -to DRAM_BA[0]
+set_location_assignment PIN_AG6 -to DRAM_BA[1]
+set_location_assignment PIN_AJ4 -to DRAM_CAS_N
+set_location_assignment PIN_AD6 -to DRAM_CKE
+set_location_assignment PIN_AE6 -to DRAM_CLK
+set_location_assignment PIN_AG5 -to DRAM_CS_N
+set_location_assignment PIN_AD10 -to DRAM_DQ[0]
+set_location_assignment PIN_AD9 -to DRAM_DQ[1]
+set_location_assignment PIN_AE9 -to DRAM_DQ[2]
+set_location_assignment PIN_AE8 -to DRAM_DQ[3]
+set_location_assignment PIN_AE7 -to DRAM_DQ[4]
+set_location_assignment PIN_AF7 -to DRAM_DQ[5]
+set_location_assignment PIN_AF6 -to DRAM_DQ[6]
+set_location_assignment PIN_AF9 -to DRAM_DQ[7]
+set_location_assignment PIN_AB13 -to DRAM_DQ[8]
+set_location_assignment PIN_AF13 -to DRAM_DQ[9]
+set_location_assignment PIN_AF12 -to DRAM_DQ[10]
+set_location_assignment PIN_AG9 -to DRAM_DQ[11]
+set_location_assignment PIN_AA13 -to DRAM_DQ[12]
+set_location_assignment PIN_AB11 -to DRAM_DQ[13]
+set_location_assignment PIN_AA12 -to DRAM_DQ[14]
+set_location_assignment PIN_AA15 -to DRAM_DQ[15]
+set_location_assignment PIN_AH11 -to DRAM_DQ[16]
+set_location_assignment PIN_AG11 -to DRAM_DQ[17]
+set_location_assignment PIN_AH12 -to DRAM_DQ[18]
+set_location_assignment PIN_AG12 -to DRAM_DQ[19]
+set_location_assignment PIN_AH13 -to DRAM_DQ[20]
+set_location_assignment PIN_AG13 -to DRAM_DQ[21]
+set_location_assignment PIN_AG14 -to DRAM_DQ[22]
+set_location_assignment PIN_AH14 -to DRAM_DQ[23]
+set_location_assignment PIN_AH9 -to DRAM_DQ[24]
+set_location_assignment PIN_AK8 -to DRAM_DQ[25]
+set_location_assignment PIN_AG10 -to DRAM_DQ[26]
+set_location_assignment PIN_AK7 -to DRAM_DQ[27]
+set_location_assignment PIN_AH7 -to DRAM_DQ[28]
+set_location_assignment PIN_AK6 -to DRAM_DQ[29]
+set_location_assignment PIN_AJ6 -to DRAM_DQ[30]
+set_location_assignment PIN_AK5 -to DRAM_DQ[31]
+set_location_assignment PIN_AF10 -to DRAM_DQM[0]
+set_location_assignment PIN_AB14 -to DRAM_DQM[1]
+set_location_assignment PIN_AH15 -to DRAM_DQM[2]
+set_location_assignment PIN_AH10 -to DRAM_DQM[3]
+set_location_assignment PIN_AK4 -to DRAM_RAS_N
+set_location_assignment PIN_AK3 -to DRAM_WE_N
+set_location_assignment PIN_AG27 -to EEP_I2C_SCLK
+set_location_assignment PIN_AG25 -to EEP_I2C_SDAT
+set_location_assignment PIN_A12 -to ENET_GTX_CLK
+set_location_assignment PIN_E16 -to ENET_INT_N
+set_location_assignment PIN_F5 -to ENET_LINK100
+set_location_assignment PIN_C16 -to ENET_MDC
+set_location_assignment PIN_C15 -to ENET_MDIO
+set_location_assignment PIN_C14 -to ENET_RST_N
+set_location_assignment PIN_L15 -to ENET_RX_CLK
+set_location_assignment PIN_G15 -to ENET_RX_COL
+set_location_assignment PIN_D6 -to ENET_RX_CRS
+set_location_assignment PIN_F15 -to ENET_RX_DATA[0]
+set_location_assignment PIN_E13 -to ENET_RX_DATA[1]
+set_location_assignment PIN_A5 -to ENET_RX_DATA[2]
+set_location_assignment PIN_B7 -to ENET_RX_DATA[3]
+set_location_assignment PIN_A8 -to ENET_RX_DV
+set_location_assignment PIN_D11 -to ENET_RX_ER
+set_location_assignment PIN_F13 -to ENET_TX_CLK
+set_location_assignment PIN_B12 -to ENET_TX_DATA[0]
+set_location_assignment PIN_E7 -to ENET_TX_DATA[1]
+set_location_assignment PIN_C13 -to ENET_TX_DATA[2]
+set_location_assignment PIN_D15 -to ENET_TX_DATA[3]
+set_location_assignment PIN_D14 -to ENET_TX_EN
+set_location_assignment PIN_D13 -to ENET_TX_ER
+set_location_assignment PIN_AF28 -to FAN_CTRL
+set_location_assignment PIN_AG18 -to FL_RESET_N
+set_location_assignment PIN_AB22 -to FS_ADDR[1]
+set_location_assignment PIN_AH19 -to FS_ADDR[2]
+set_location_assignment PIN_AK19 -to FS_ADDR[3]
+set_location_assignment PIN_AJ18 -to FS_ADDR[4]
+set_location_assignment PIN_AA18 -to FS_ADDR[5]
+set_location_assignment PIN_AH18 -to FS_ADDR[6]
+set_location_assignment PIN_AK17 -to FS_ADDR[7]
+set_location_assignment PIN_Y20 -to FS_ADDR[8]
+set_location_assignment PIN_AK21 -to FS_ADDR[9]
+set_location_assignment PIN_AH21 -to FS_ADDR[10]
+set_location_assignment PIN_AG21 -to FS_ADDR[11]
+set_location_assignment PIN_AG22 -to FS_ADDR[12]
+set_location_assignment PIN_AD22 -to FS_ADDR[13]
+set_location_assignment PIN_AE24 -to FS_ADDR[14]
+set_location_assignment PIN_AD23 -to FS_ADDR[15]
+set_location_assignment PIN_AB21 -to FS_ADDR[16]
+set_location_assignment PIN_AH17 -to FS_ADDR[17]
+set_location_assignment PIN_AE17 -to FS_ADDR[18]
+set_location_assignment PIN_AG20 -to FS_ADDR[19]
+set_location_assignment PIN_AK20 -to FS_ADDR[20]
+set_location_assignment PIN_AE19 -to FS_ADDR[21]
+set_location_assignment PIN_AA16 -to FS_ADDR[22]
+set_location_assignment PIN_AF15 -to FS_ADDR[23]
+set_location_assignment PIN_AG15 -to FS_ADDR[24]
+set_location_assignment PIN_Y17 -to FS_ADDR[25]
+set_location_assignment PIN_AB16 -to FS_ADDR[26]
+set_location_assignment PIN_AG19 -to FL_CE_N
+set_location_assignment PIN_AJ19 -to FL_OE_N
+set_location_assignment PIN_AF19 -to FL_RY
+set_location_assignment PIN_AG17 -to FL_WE_N
+set_location_assignment PIN_AK18 -to FL_WP_N
+set_location_assignment PIN_AK29 -to FS_DQ[0]
+set_location_assignment PIN_AE23 -to FS_DQ[1]
+set_location_assignment PIN_AH24 -to FS_DQ[2]
+set_location_assignment PIN_AH23 -to FS_DQ[3]
+set_location_assignment PIN_AA21 -to FS_DQ[4]
+set_location_assignment PIN_AE20 -to FS_DQ[5]
+set_location_assignment PIN_Y19 -to FS_DQ[6]
+set_location_assignment PIN_AA17 -to FS_DQ[7]
+set_location_assignment PIN_AB17 -to FS_DQ[8]
+set_location_assignment PIN_Y18 -to FS_DQ[9]
+set_location_assignment PIN_AA20 -to FS_DQ[10]
+set_location_assignment PIN_AE21 -to FS_DQ[11]
+set_location_assignment PIN_AH22 -to FS_DQ[12]
+set_location_assignment PIN_AJ24 -to FS_DQ[13]
+set_location_assignment PIN_AE22 -to FS_DQ[14]
+set_location_assignment PIN_AK28 -to FS_DQ[15]
+set_location_assignment PIN_AK9 -to FS_DQ[16]
+set_location_assignment PIN_AJ10 -to FS_DQ[17]
+set_location_assignment PIN_AK11 -to FS_DQ[18]
+set_location_assignment PIN_AK12 -to FS_DQ[19]
+set_location_assignment PIN_AJ13 -to FS_DQ[20]
+set_location_assignment PIN_AK15 -to FS_DQ[21]
+set_location_assignment PIN_AC16 -to FS_DQ[22]
+set_location_assignment PIN_AH16 -to FS_DQ[23]
+set_location_assignment PIN_AG16 -to FS_DQ[24]
+set_location_assignment PIN_AD16 -to FS_DQ[25]
+set_location_assignment PIN_AJ15 -to FS_DQ[26]
+set_location_assignment PIN_AK14 -to FS_DQ[27]
+set_location_assignment PIN_AK13 -to FS_DQ[28]
+set_location_assignment PIN_AJ12 -to FS_DQ[29]
+set_location_assignment PIN_AK10 -to FS_DQ[30]
+set_location_assignment PIN_AJ9 -to FS_DQ[31]
+set_location_assignment PIN_G16 -to GPIO[0]
+set_location_assignment PIN_F17 -to GPIO[1]
+set_location_assignment PIN_D18 -to GPIO[2]
+set_location_assignment PIN_F18 -to GPIO[3]
+set_location_assignment PIN_D19 -to GPIO[4]
+set_location_assignment PIN_K21 -to GPIO[5]
+set_location_assignment PIN_F19 -to GPIO[6]
+set_location_assignment PIN_K22 -to GPIO[7]
+set_location_assignment PIN_B21 -to GPIO[8]
+set_location_assignment PIN_C21 -to GPIO[9]
+set_location_assignment PIN_D22 -to GPIO[10]
+set_location_assignment PIN_D21 -to GPIO[11]
+set_location_assignment PIN_D23 -to GPIO[12]
+set_location_assignment PIN_D24 -to GPIO[13]
+set_location_assignment PIN_B28 -to GPIO[14]
+set_location_assignment PIN_C25 -to GPIO[15]
+set_location_assignment PIN_C26 -to GPIO[16]
+set_location_assignment PIN_D28 -to GPIO[17]
+set_location_assignment PIN_D25 -to GPIO[18]
+set_location_assignment PIN_F20 -to GPIO[19]
+set_location_assignment PIN_E21 -to GPIO[20]
+set_location_assignment PIN_F23 -to GPIO[21]
+set_location_assignment PIN_G20 -to GPIO[22]
+set_location_assignment PIN_F22 -to GPIO[23]
+set_location_assignment PIN_G22 -to GPIO[24]
+set_location_assignment PIN_G24 -to GPIO[25]
+set_location_assignment PIN_G23 -to GPIO[26]
+set_location_assignment PIN_A25 -to GPIO[27]
+set_location_assignment PIN_A26 -to GPIO[28]
+set_location_assignment PIN_A19 -to GPIO[29]
+set_location_assignment PIN_A28 -to GPIO[30]
+set_location_assignment PIN_A27 -to GPIO[31]
+set_location_assignment PIN_B30 -to GPIO[32]
+set_location_assignment PIN_AG28 -to GPIO[33]
+set_location_assignment PIN_AG26 -to GPIO[34]
+set_location_assignment PIN_Y21 -to GPIO[35]
+set_location_assignment PIN_AC30 -to G_SENSOR_INT1
+set_location_assignment PIN_AK27 -to G_SENSOR_SCLK
+set_location_assignment PIN_AK26 -to G_SENSOR_SDAT
+set_location_assignment PIN_E15 -to HEX0[0]
+set_location_assignment PIN_E12 -to HEX0[1]
+set_location_assignment PIN_G11 -to HEX0[2]
+set_location_assignment PIN_F11 -to HEX0[3]
+set_location_assignment PIN_F16 -to HEX0[4]
+set_location_assignment PIN_D16 -to HEX0[5]
+set_location_assignment PIN_F14 -to HEX0[6]
+set_location_assignment PIN_G14 -to HEX1[0]
+set_location_assignment PIN_B13 -to HEX1[1]
+set_location_assignment PIN_G13 -to HEX1[2]
+set_location_assignment PIN_F12 -to HEX1[3]
+set_location_assignment PIN_G12 -to HEX1[4]
+set_location_assignment PIN_J9 -to HEX1[5]
+set_location_assignment PIN_G10 -to HEX1[6]
+set_location_assignment PIN_G8 -to HEX2[0]
+set_location_assignment PIN_G7 -to HEX2[1]
+set_location_assignment PIN_F7 -to HEX2[2]
+set_location_assignment PIN_AG30 -to HEX2[3]
+set_location_assignment PIN_F6 -to HEX2[4]
+set_location_assignment PIN_F4 -to HEX2[5]
+set_location_assignment PIN_F10 -to HEX2[6]
+set_location_assignment PIN_D10 -to HEX3[0]
+set_location_assignment PIN_D7 -to HEX3[1]
+set_location_assignment PIN_E6 -to HEX3[2]
+set_location_assignment PIN_E4 -to HEX3[3]
+set_location_assignment PIN_E3 -to HEX3[4]
+set_location_assignment PIN_D5 -to HEX3[5]
+set_location_assignment PIN_D4 -to HEX3[6]
+set_location_assignment PIN_A14 -to HEX4[0]
+set_location_assignment PIN_A13 -to HEX4[1]
+set_location_assignment PIN_C7 -to HEX4[2]
+set_location_assignment PIN_C6 -to HEX4[3]
+set_location_assignment PIN_C5 -to HEX4[4]
+set_location_assignment PIN_C4 -to HEX4[5]
+set_location_assignment PIN_C3 -to HEX4[6]
+set_location_assignment PIN_D3 -to HEX5[0]
+set_location_assignment PIN_A10 -to HEX5[1]
+set_location_assignment PIN_A9 -to HEX5[2]
+set_location_assignment PIN_A7 -to HEX5[3]
+set_location_assignment PIN_A6 -to HEX5[4]
+set_location_assignment PIN_A11 -to HEX5[5]
+set_location_assignment PIN_B6 -to HEX5[6]
+set_location_assignment PIN_B9 -to HEX6[0]
+set_location_assignment PIN_B10 -to HEX6[1]
+set_location_assignment PIN_C8 -to HEX6[2]
+set_location_assignment PIN_C9 -to HEX6[3]
+set_location_assignment PIN_D8 -to HEX6[4]
+set_location_assignment PIN_D9 -to HEX6[5]
+set_location_assignment PIN_E9 -to HEX6[6]
+set_location_assignment PIN_E10 -to HEX7[0]
+set_location_assignment PIN_F8 -to HEX7[1]
+set_location_assignment PIN_F9 -to HEX7[2]
+set_location_assignment PIN_C10 -to HEX7[3]
+set_location_assignment PIN_C11 -to HEX7[4]
+set_location_assignment PIN_C12 -to HEX7[5]
+set_location_assignment PIN_D12 -to HEX7[6]
+set_location_assignment PIN_K15 -to HSMC_CLKIN0
+set_location_assignment PIN_V30 -to HSMC_CLKIN_N1
+set_location_assignment PIN_T30 -to HSMC_CLKIN_N2
+set_location_assignment PIN_V29 -to HSMC_CLKIN_P1
+set_location_assignment PIN_T29 -to HSMC_CLKIN_P2
+set_location_assignment PIN_G6 -to HSMC_CLKOUT0
+set_location_assignment PIN_AB28 -to HSMC_CLKOUT_N1
+set_location_assignment PIN_Y28 -to HSMC_CLKOUT_N2
+set_location_assignment PIN_AB27 -to HSMC_CLKOUT_P1
+set_location_assignment PIN_AA28 -to HSMC_CLKOUT_P2
+set_location_assignment PIN_AC25 -to HSMC_D[0]
+set_location_assignment PIN_E27 -to HSMC_D[1]
+set_location_assignment PIN_AB26 -to HSMC_D[2]
+set_location_assignment PIN_E28 -to HSMC_D[3]
+set_location_assignment PIN_AD26 -to HSMC_I2C_SCLK
+set_location_assignment PIN_AD25 -to HSMC_I2C_SDAT
+set_location_assignment PIN_G27 -to HSMC_RX_D_N[0]
+set_location_assignment PIN_G29 -to HSMC_RX_D_N[1]
+set_location_assignment PIN_H27 -to HSMC_RX_D_N[2]
+set_location_assignment PIN_K29 -to HSMC_RX_D_N[3]
+set_location_assignment PIN_L28 -to HSMC_RX_D_N[4]
+set_location_assignment PIN_M28 -to HSMC_RX_D_N[5]
+set_location_assignment PIN_N30 -to HSMC_RX_D_N[6]
+set_location_assignment PIN_P28 -to HSMC_RX_D_N[7]
+set_location_assignment PIN_R28 -to HSMC_RX_D_N[8]
+set_location_assignment PIN_U28 -to HSMC_RX_D_N[9]
+set_location_assignment PIN_W28 -to HSMC_RX_D_N[10]
+set_location_assignment PIN_W30 -to HSMC_RX_D_N[11]
+set_location_assignment PIN_M30 -to HSMC_RX_D_N[12]
+set_location_assignment PIN_Y27 -to HSMC_RX_D_N[13]
+set_location_assignment PIN_AA29 -to HSMC_RX_D_N[14]
+set_location_assignment PIN_AD28 -to HSMC_RX_D_N[15]
+set_location_assignment PIN_AE28 -to HSMC_RX_D_N[16]
+set_location_assignment PIN_G26 -to HSMC_RX_D_P[0]
+set_location_assignment PIN_G28 -to HSMC_RX_D_P[1]
+set_location_assignment PIN_J27 -to HSMC_RX_D_P[2]
+set_location_assignment PIN_K28 -to HSMC_RX_D_P[3]
+set_location_assignment PIN_L27 -to HSMC_RX_D_P[4]
+set_location_assignment PIN_M27 -to HSMC_RX_D_P[5]
+set_location_assignment PIN_N29 -to HSMC_RX_D_P[6]
+set_location_assignment PIN_P27 -to HSMC_RX_D_P[7]
+set_location_assignment PIN_R27 -to HSMC_RX_D_P[8]
+set_location_assignment PIN_U27 -to HSMC_RX_D_P[9]
+set_location_assignment PIN_W27 -to HSMC_RX_D_P[10]
+set_location_assignment PIN_W29 -to HSMC_RX_D_P[11]
+set_location_assignment PIN_M29 -to HSMC_RX_D_P[12]
+set_location_assignment PIN_AA27 -to HSMC_RX_D_P[13]
+set_location_assignment PIN_AB29 -to HSMC_RX_D_P[14]
+set_location_assignment PIN_AD27 -to HSMC_RX_D_P[15]
+set_location_assignment PIN_AE27 -to HSMC_RX_D_P[16]
+set_location_assignment PIN_H28 -to HSMC_TX_D_N[0]
+set_location_assignment PIN_F29 -to HSMC_TX_D_N[1]
+set_location_assignment PIN_D30 -to HSMC_TX_D_N[2]
+set_location_assignment PIN_E30 -to HSMC_TX_D_N[3]
+set_location_assignment PIN_G30 -to HSMC_TX_D_N[4]
+set_location_assignment PIN_J30 -to HSMC_TX_D_N[5]
+set_location_assignment PIN_K27 -to HSMC_TX_D_N[6]
+set_location_assignment PIN_K30 -to HSMC_TX_D_N[7]
+set_location_assignment PIN_T25 -to HSMC_TX_D_N[8]
+set_location_assignment PIN_N28 -to HSMC_TX_D_N[9]
+set_location_assignment PIN_V26 -to HSMC_TX_D_N[10]
+set_location_assignment PIN_Y30 -to HSMC_TX_D_N[11]
+set_location_assignment PIN_AC28 -to HSMC_TX_D_N[12]
+set_location_assignment PIN_AD30 -to HSMC_TX_D_N[13]
+set_location_assignment PIN_AE30 -to HSMC_TX_D_N[14]
+set_location_assignment PIN_AH30 -to HSMC_TX_D_N[15]
+set_location_assignment PIN_AG29 -to HSMC_TX_D_N[16]
+set_location_assignment PIN_J28 -to HSMC_TX_D_P[0]
+set_location_assignment PIN_F28 -to HSMC_TX_D_P[1]
+set_location_assignment PIN_D29 -to HSMC_TX_D_P[2]
+set_location_assignment PIN_F30 -to HSMC_TX_D_P[3]
+set_location_assignment PIN_H30 -to HSMC_TX_D_P[4]
+set_location_assignment PIN_J29 -to HSMC_TX_D_P[5]
+set_location_assignment PIN_K26 -to HSMC_TX_D_P[6]
+set_location_assignment PIN_L30 -to HSMC_TX_D_P[7]
+set_location_assignment PIN_U25 -to HSMC_TX_D_P[8]
+set_location_assignment PIN_N27 -to HSMC_TX_D_P[9]
+set_location_assignment PIN_V25 -to HSMC_TX_D_P[10]
+set_location_assignment PIN_AA30 -to HSMC_TX_D_P[11]
+set_location_assignment PIN_AC27 -to HSMC_TX_D_P[12]
+set_location_assignment PIN_AD29 -to HSMC_TX_D_P[13]
+set_location_assignment PIN_AE29 -to HSMC_TX_D_P[14]
+set_location_assignment PIN_AJ30 -to HSMC_TX_D_P[15]
+set_location_assignment PIN_AH29 -to HSMC_TX_D_P[16]
+set_location_assignment PIN_C27 -to I2C_SCLK
+set_location_assignment PIN_G21 -to I2C_SDAT
+set_location_assignment PIN_AH28 -to IRDA_RXD
+set_location_assignment PIN_AA26 -to KEY[0]
+set_location_assignment PIN_AE25 -to KEY[1]
+set_location_assignment PIN_AF30 -to KEY[2]
+set_location_assignment PIN_AE26 -to KEY[3]
+set_location_assignment PIN_AG4 -to LCD_DATA[0]
+set_location_assignment PIN_AF3 -to LCD_DATA[1]
+set_location_assignment PIN_AH3 -to LCD_DATA[2]
+set_location_assignment PIN_AE5 -to LCD_DATA[3]
+set_location_assignment PIN_AH2 -to LCD_DATA[4]
+set_location_assignment PIN_AE3 -to LCD_DATA[5]
+set_location_assignment PIN_AH4 -to LCD_DATA[6]
+set_location_assignment PIN_AE4 -to LCD_DATA[7]
+set_location_assignment PIN_AF4 -to LCD_EN
+set_location_assignment PIN_AF27 -to LCD_ON
+set_location_assignment PIN_AG3 -to LCD_RS
+set_location_assignment PIN_AJ3 -to LCD_RW
+set_location_assignment PIN_AA25 -to LEDG[0]
+set_location_assignment PIN_AB25 -to LEDG[1]
+set_location_assignment PIN_F27 -to LEDG[2]
+set_location_assignment PIN_F26 -to LEDG[3]
+set_location_assignment PIN_W26 -to LEDG[4]
+set_location_assignment PIN_Y22 -to LEDG[5]
+set_location_assignment PIN_Y25 -to LEDG[6]
+set_location_assignment PIN_AA22 -to LEDG[7]
+set_location_assignment PIN_J25 -to LEDG[8]
+set_location_assignment PIN_T23 -to LEDR[0]
+set_location_assignment PIN_T24 -to LEDR[1]
+set_location_assignment PIN_V27 -to LEDR[2]
+set_location_assignment PIN_W25 -to LEDR[3]
+set_location_assignment PIN_T21 -to LEDR[4]
+set_location_assignment PIN_T26 -to LEDR[5]
+set_location_assignment PIN_R25 -to LEDR[6]
+set_location_assignment PIN_T27 -to LEDR[7]
+set_location_assignment PIN_P25 -to LEDR[8]
+set_location_assignment PIN_R24 -to LEDR[9]
+set_location_assignment PIN_P21 -to LEDR[10]
+set_location_assignment PIN_N24 -to LEDR[11]
+set_location_assignment PIN_N21 -to LEDR[12]
+set_location_assignment PIN_M25 -to LEDR[13]
+set_location_assignment PIN_K24 -to LEDR[14]
+set_location_assignment PIN_L25 -to LEDR[15]
+set_location_assignment PIN_M21 -to LEDR[16]
+set_location_assignment PIN_M22 -to LEDR[17]
+set_location_assignment PIN_A4 -to PCIE_PERST_N
+set_location_assignment PIN_V15 -to PCIE_REFCLK_P
+set_location_assignment PIN_AC2 -to PCIE_RX_P[0]
+set_location_assignment PIN_AA2 -to PCIE_RX_P[1]
+set_location_assignment PIN_AB4 -to PCIE_TX_P[0]
+set_location_assignment PIN_Y4 -to PCIE_TX_P[1]
+set_location_assignment PIN_C29 -to PCIE_WAKE_N
+set_location_assignment PIN_AH25 -to SD_CLK
+set_location_assignment PIN_AF18 -to SD_CMD
+set_location_assignment PIN_AH27 -to SD_DAT[0]
+set_location_assignment PIN_AJ28 -to SD_DAT[1]
+set_location_assignment PIN_AD24 -to SD_DAT[2]
+set_location_assignment PIN_AE18 -to SD_DAT[3]
+set_location_assignment PIN_AJ27 -to SD_WP_N
+set_location_assignment PIN_AK16 -to SMA_CLKIN
+set_location_assignment PIN_AF25 -to SMA_CLKOUT
+set_location_assignment PIN_AJ21 -to SSRAM0_CE_N
+set_location_assignment PIN_AG23 -to SSRAM1_CE_N
+set_location_assignment PIN_AK25 -to SSRAM_ADSC_N
+set_location_assignment PIN_AJ25 -to SSRAM_ADSP_N
+set_location_assignment PIN_AH26 -to SSRAM_ADV_N
+set_location_assignment PIN_AF22 -to SSRAM_BE[0]
+set_location_assignment PIN_AK22 -to SSRAM_BE[1]
+set_location_assignment PIN_AJ22 -to SSRAM_BE[2]
+set_location_assignment PIN_AF21 -to SSRAM_BE[3]
+set_location_assignment PIN_AF24 -to SSRAM_CLK
+set_location_assignment PIN_AK23 -to SSRAM_GW_N
+set_location_assignment PIN_AG24 -to SSRAM_OE_N
+set_location_assignment PIN_AK24 -to SSRAM_WE_N
+set_location_assignment PIN_V28 -to SW[0]
+set_location_assignment PIN_U30 -to SW[1]
+set_location_assignment PIN_V21 -to SW[2]
+set_location_assignment PIN_C2 -to SW[3]
+set_location_assignment PIN_AB30 -to SW[4]
+set_location_assignment PIN_U21 -to SW[5]
+set_location_assignment PIN_T28 -to SW[6]
+set_location_assignment PIN_R30 -to SW[7]
+set_location_assignment PIN_P30 -to SW[8]
+set_location_assignment PIN_R29 -to SW[9]
+set_location_assignment PIN_R26 -to SW[10]
+set_location_assignment PIN_N26 -to SW[11]
+set_location_assignment PIN_M26 -to SW[12]
+set_location_assignment PIN_N25 -to SW[13]
+set_location_assignment PIN_J26 -to SW[14]
+set_location_assignment PIN_K25 -to SW[15]
+set_location_assignment PIN_C30 -to SW[16]
+set_location_assignment PIN_H25 -to SW[17]
+set_location_assignment PIN_B15 -to TD_CLK27
+set_location_assignment PIN_C17 -to TD_DATA[0]
+set_location_assignment PIN_D17 -to TD_DATA[1]
+set_location_assignment PIN_A16 -to TD_DATA[2]
+set_location_assignment PIN_B16 -to TD_DATA[3]
+set_location_assignment PIN_G18 -to TD_DATA[4]
+set_location_assignment PIN_G17 -to TD_DATA[5]
+set_location_assignment PIN_K18 -to TD_DATA[6]
+set_location_assignment PIN_K17 -to TD_DATA[7]
+set_location_assignment PIN_C28 -to TD_HS
+set_location_assignment PIN_E25 -to TD_RESET_N
+set_location_assignment PIN_E22 -to TD_VS
+set_location_assignment PIN_D26 -to UART_CTS
+set_location_assignment PIN_A29 -to UART_RTS
+set_location_assignment PIN_B27 -to UART_RXD
+set_location_assignment PIN_H24 -to UART_TXD
+set_location_assignment PIN_E24 -to VGA_B[0]
+set_location_assignment PIN_C24 -to VGA_B[1]
+set_location_assignment PIN_B25 -to VGA_B[2]
+set_location_assignment PIN_C23 -to VGA_B[3]
+set_location_assignment PIN_F24 -to VGA_B[4]
+set_location_assignment PIN_A23 -to VGA_B[5]
+set_location_assignment PIN_G25 -to VGA_B[6]
+set_location_assignment PIN_C22 -to VGA_B[7]
+set_location_assignment PIN_F25 -to VGA_BLANK_N
+set_location_assignment PIN_D27 -to VGA_CLK
+set_location_assignment PIN_D20 -to VGA_G[0]
+set_location_assignment PIN_C20 -to VGA_G[1]
+set_location_assignment PIN_A20 -to VGA_G[2]
+set_location_assignment PIN_K19 -to VGA_G[3]
+set_location_assignment PIN_A21 -to VGA_G[4]
+set_location_assignment PIN_F21 -to VGA_G[5]
+set_location_assignment PIN_A22 -to VGA_G[6]
+set_location_assignment PIN_B22 -to VGA_G[7]
+set_location_assignment PIN_B24 -to VGA_HS
+set_location_assignment PIN_A17 -to VGA_R[0]
+set_location_assignment PIN_C18 -to VGA_R[1]
+set_location_assignment PIN_B18 -to VGA_R[2]
+set_location_assignment PIN_A18 -to VGA_R[3]
+set_location_assignment PIN_E18 -to VGA_R[4]
+set_location_assignment PIN_E19 -to VGA_R[5]
+set_location_assignment PIN_B19 -to VGA_R[6]
+set_location_assignment PIN_C19 -to VGA_R[7]
+set_location_assignment PIN_AH20 -to VGA_SYNC_N
+set_location_assignment PIN_A24 -to VGA_VS
+
+set_instance_assignment -name VIRTUAL_PIN ON -to FS_ADDR[0]
+#============================================================
+
+
+
+set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
+set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
+set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
+set_global_assignment -name STRATIX_DEVICE_IO_STANDARD "2.5 V"
+set_global_assignment -name VQM_FILE ../top.vqm
+set_global_assignment -name SDC_FILE de2i_150_golden_top.sdc
+set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
+set_global_assignment -name MAX_CORE_JUNCTION_TEMP 85
+set_global_assignment -name POWER_PRESET_COOLING_SOLUTION "23 MM HEAT SINK WITH 200 LFPM AIRFLOW"
+set_global_assignment -name POWER_BOARD_THERMAL_MODEL "NONE (CONSERVATIVE)"
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/examples/intel/DE2i-150/quartus_compile/runme_quartus
+++ b/examples/intel/DE2i-150/quartus_compile/runme_quartus
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export REV="de2i_150_golden_top"
+
+quartus_map -c $REV top && \
+    quartus_fit -c $REV top && \
+	quartus_eda -c $REV top && \
+	    quartus_asm -c $REV top

--- a/examples/intel/DE2i-150/run_cycloneiv
+++ b/examples/intel/DE2i-150/run_cycloneiv
@@ -1,0 +1,1 @@
+yosys -p "synth_intel -family cycloneiv -top top -vout top.vqm" top.v sevenseg.v

--- a/examples/intel/DE2i-150/runme_postsynth
+++ b/examples/intel/DE2i-150/runme_postsynth
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+iverilog -D POST_IMPL -o verif_post -s tb_top tb_top.v top.vqm $(yosys-config --datdir/altera_intel/max10/cells_comb_max10.v)
+vvp -N verif_post
+

--- a/examples/intel/DE2i-150/sevenseg.v
+++ b/examples/intel/DE2i-150/sevenseg.v
@@ -1,0 +1,25 @@
+module sevenseg ( output reg    [6:0] HEX0,
+                  input      [3:0] SW );
+
+   always @(*) begin
+     case(SW)
+        4'h1: HEX0 = 7'b1111001;	// ---t----
+	4'h2: HEX0 = 7'b0100100; 	// |	  |
+	4'h3: HEX0 = 7'b0110000; 	// lt	 rt
+	4'h4: HEX0 = 7'b0011001; 	// |	  |
+	4'h5: HEX0 = 7'b0010010; 	// ---m----
+	4'h6: HEX0 = 7'b0000010; 	// |	  |
+	4'h7: HEX0 = 7'b1111000; 	// lb	 rb
+	4'h8: HEX0 = 7'b0000000; 	// |	  |
+	4'h9: HEX0 = 7'b0011000; 	// ---b----
+	4'ha: HEX0 = 7'b0001000;
+	4'hb: HEX0 = 7'b0000011;
+	4'hc: HEX0 = 7'b1000110;
+	4'hd: HEX0 = 7'b0100001;
+	4'he: HEX0 = 7'b0000110;
+	4'hf: HEX0 = 7'b0001110;
+	4'h0: HEX0 = 7'b1000000;
+     endcase // case (din)
+   end 
+   
+endmodule

--- a/examples/intel/DE2i-150/top.v
+++ b/examples/intel/DE2i-150/top.v
@@ -1,0 +1,14 @@
+module top ( output wire [6:0] HEX0, HEX1, HEX2, HEX3, HEX4, HEX5, HEX6, HEX7,
+             input  wire [15:0] SW );
+             
+  
+    sevenseg UUD0 (.HEX0(HEX0), .SW(4'h7));
+    sevenseg UUD1 (.HEX0(HEX1), .SW(4'h1));
+    sevenseg UUD2 (.HEX0(HEX2), .SW(4'h0));
+    sevenseg UUD3 (.HEX0(HEX3), .SW(4'h2));
+    sevenseg UUD4 (.HEX0(HEX4), .SW(SW[3:0]));
+    sevenseg UUD5 (.HEX0(HEX5), .SW(SW[7:4]));
+    sevenseg UUD6 (.HEX0(HEX6), .SW(SW[11:8]));
+    sevenseg UUD7 (.HEX0(HEX7), .SW(SW[15:12]));
+    
+endmodule

--- a/examples/intel/MAX10/run_max10
+++ b/examples/intel/MAX10/run_max10
@@ -1,0 +1,1 @@
+yosys -p "synth_intel -family max10 -top top -vout top.vqm" top.v sevenseg.v

--- a/examples/intel/MAX10/runme_postsynth
+++ b/examples/intel/MAX10/runme_postsynth
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+iverilog -D POST_IMPL -o verif_post -s tb_top tb_top.v top.vqm $(yosys-config --datdir/altera_intel/max10/cells_comb_max10.v)
+vvp -N verif_post
+

--- a/examples/intel/MAX10/sevenseg.v
+++ b/examples/intel/MAX10/sevenseg.v
@@ -1,0 +1,25 @@
+module sevenseg ( output reg    [6:0] HEX0,
+                  input      [3:0] SW );
+
+   always @(*) begin
+     case(SW)
+        4'h1: HEX0 = 7'b1111001;	// ---t----
+	4'h2: HEX0 = 7'b0100100; 	// |	  |
+	4'h3: HEX0 = 7'b0110000; 	// lt	 rt
+	4'h4: HEX0 = 7'b0011001; 	// |	  |
+	4'h5: HEX0 = 7'b0010010; 	// ---m----
+	4'h6: HEX0 = 7'b0000010; 	// |	  |
+	4'h7: HEX0 = 7'b1111000; 	// lb	 rb
+	4'h8: HEX0 = 7'b0000000; 	// |	  |
+	4'h9: HEX0 = 7'b0011000; 	// ---b----
+	4'ha: HEX0 = 7'b0001000;
+	4'hb: HEX0 = 7'b0000011;
+	4'hc: HEX0 = 7'b1000110;
+	4'hd: HEX0 = 7'b0100001;
+	4'he: HEX0 = 7'b0000110;
+	4'hf: HEX0 = 7'b0001110;
+	4'h0: HEX0 = 7'b1000000;
+     endcase // case (din)
+   end 
+   
+endmodule

--- a/examples/intel/MAX10/top.v
+++ b/examples/intel/MAX10/top.v
@@ -1,0 +1,14 @@
+module top ( output wire [6:0] HEX0, HEX1, HEX2, HEX3, HEX4, HEX5, HEX6, HEX7,
+             input  wire [15:0] SW );
+             
+  
+    sevenseg UUD0 (.HEX0(HEX0), .SW(4'h7));
+    sevenseg UUD1 (.HEX0(HEX1), .SW(4'h1));
+    sevenseg UUD2 (.HEX0(HEX2), .SW(4'h0));
+    sevenseg UUD3 (.HEX0(HEX3), .SW(4'h2));
+    sevenseg UUD4 (.HEX0(HEX4), .SW(SW[3:0]));
+    sevenseg UUD5 (.HEX0(HEX5), .SW(SW[7:4]));
+    sevenseg UUD6 (.HEX0(HEX6), .SW(SW[11:8]));
+    sevenseg UUD7 (.HEX0(HEX7), .SW(SW[15:12]));
+    
+endmodule

--- a/examples/intel/asicworld_lfsr/README
+++ b/examples/intel/asicworld_lfsr/README
@@ -1,0 +1,6 @@
+Source of the files:
+http://www.asic-world.com/examples/verilog/lfsr.html
+
+Run first: runme_presynth
+Generate output netlist with run_max10 or run_cycloneiv
+Then, check with: runme_postsynth

--- a/examples/intel/asicworld_lfsr/lfsr_updown.v
+++ b/examples/intel/asicworld_lfsr/lfsr_updown.v
@@ -1,0 +1,35 @@
+
+module lfsr_updown (
+clk       ,   // Clock input
+reset     ,   // Reset input
+enable    ,   // Enable input
+up_down   ,   // Up Down input
+count     ,   // Count output
+overflow      // Overflow output
+);
+
+ input clk;
+ input reset;
+ input enable; 
+ input up_down;
+
+ output [7 : 0] count;
+ output overflow;
+
+ reg [7 : 0] count;
+
+ assign overflow = (up_down) ? (count == {{7{1'b0}}, 1'b1}) : 
+                               (count == {1'b1, {7{1'b0}}}) ;
+
+ always @(posedge clk)
+ if (reset) 
+    count <= {7{1'b0}};
+ else if (enable) begin
+    if (up_down) begin
+      count <= {~(^(count & 7'b01100011)),count[7:1]};
+    end else begin
+      count <= {count[5:0],~(^(count &  7'b10110001))};
+    end
+ end
+
+endmodule

--- a/examples/intel/asicworld_lfsr/lfsr_updown_tb.v
+++ b/examples/intel/asicworld_lfsr/lfsr_updown_tb.v
@@ -1,0 +1,34 @@
+module tb();
+ reg clk;
+ reg reset;
+ reg enable;
+ reg up_down;
+
+ wire [7 : 0] count;
+ wire overflow;
+
+initial begin
+  $monitor("rst %b en %b updown %b cnt %b overflow %b",
+     reset,enable,up_down,count, overflow);
+  clk = 0;
+  reset = 1;
+  enable = 0;
+  up_down = 0;
+  #10 reset = 0;
+  #1 enable = 1;
+  #20 up_down = 1;
+  #30 $finish;
+end
+
+always #1 clk = ~clk;
+
+lfsr_updown U(
+.clk      ( clk      ),
+.reset    ( reset    ),
+.enable   ( enable   ),
+.up_down  ( up_down  ),
+.count    ( count    ),
+.overflow ( overflow )
+);
+
+endmodule 

--- a/examples/intel/asicworld_lfsr/presynth
+++ b/examples/intel/asicworld_lfsr/presynth
@@ -1,0 +1,121 @@
+#! /usr/local/bin/vvp
+:ivl_version "11.0 (devel)" "(s20150603-462-gfbd69e1-dirty)";
+:ivl_delay_selection "TYPICAL";
+:vpi_time_precision + 0;
+:vpi_module "system";
+:vpi_module "vhdl_sys";
+:vpi_module "vhdl_textio";
+:vpi_module "v2005_math";
+:vpi_module "va_math";
+S_0x1a84680 .scope module, "tb" "tb" 2 1;
+ .timescale 0 0;
+v0x1a99c60_0 .var "clk", 0 0;
+v0x1a99d20_0 .net "count", 7 0, v0x1a996f0_0;  1 drivers
+v0x1a99df0_0 .var "enable", 0 0;
+v0x1a99ef0_0 .net "overflow", 0 0, L_0x1a9a3c0;  1 drivers
+v0x1a99fc0_0 .var "reset", 0 0;
+v0x1a9a060_0 .var "up_down", 0 0;
+S_0x1a84810 .scope module, "U" "lfsr_updown" 2 25, 3 2 0, S_0x1a84680;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk"
+    .port_info 1 /INPUT 1 "reset"
+    .port_info 2 /INPUT 1 "enable"
+    .port_info 3 /INPUT 1 "up_down"
+    .port_info 4 /OUTPUT 8 "count"
+    .port_info 5 /OUTPUT 1 "overflow"
+L_0x7f9394325018 .functor BUFT 1, C4<00000001>, C4<0>, C4<0>, C4<0>;
+v0x1a81860_0 .net/2u *"_s0", 7 0, L_0x7f9394325018;  1 drivers
+v0x1a99370_0 .net *"_s2", 0 0, L_0x1a9a130;  1 drivers
+L_0x7f9394325060 .functor BUFT 1, C4<10000000>, C4<0>, C4<0>, C4<0>;
+v0x1a99430_0 .net/2u *"_s4", 7 0, L_0x7f9394325060;  1 drivers
+v0x1a99520_0 .net *"_s6", 0 0, L_0x1a9a2a0;  1 drivers
+v0x1a995e0_0 .net "clk", 0 0, v0x1a99c60_0;  1 drivers
+v0x1a996f0_0 .var "count", 7 0;
+v0x1a997d0_0 .net "enable", 0 0, v0x1a99df0_0;  1 drivers
+v0x1a99890_0 .net "overflow", 0 0, L_0x1a9a3c0;  alias, 1 drivers
+v0x1a99950_0 .net "reset", 0 0, v0x1a99fc0_0;  1 drivers
+v0x1a99aa0_0 .net "up_down", 0 0, v0x1a9a060_0;  1 drivers
+E_0x1a820b0 .event posedge, v0x1a995e0_0;
+L_0x1a9a130 .cmp/eq 8, v0x1a996f0_0, L_0x7f9394325018;
+L_0x1a9a2a0 .cmp/eq 8, v0x1a996f0_0, L_0x7f9394325060;
+L_0x1a9a3c0 .functor MUXZ 1, L_0x1a9a2a0, L_0x1a9a130, v0x1a9a060_0, C4<>;
+    .scope S_0x1a84810;
+T_0 ;
+    %wait E_0x1a820b0;
+    %load/vec4 v0x1a99950_0;
+    %flag_set/vec4 8;
+    %jmp/0xz  T_0.0, 8;
+    %pushi/vec4 0, 0, 8;
+    %assign/vec4 v0x1a996f0_0, 0;
+    %jmp T_0.1;
+T_0.0 ;
+    %load/vec4 v0x1a997d0_0;
+    %flag_set/vec4 8;
+    %jmp/0xz  T_0.2, 8;
+    %load/vec4 v0x1a99aa0_0;
+    %flag_set/vec4 8;
+    %jmp/0xz  T_0.4, 8;
+    %load/vec4 v0x1a996f0_0;
+    %pushi/vec4 99, 0, 8;
+    %and;
+    %xor/r;
+    %inv;
+    %load/vec4 v0x1a996f0_0;
+    %parti/s 7, 1, 2;
+    %concat/vec4; draw_concat_vec4
+    %assign/vec4 v0x1a996f0_0, 0;
+    %jmp T_0.5;
+T_0.4 ;
+    %load/vec4 v0x1a996f0_0;
+    %parti/s 6, 0, 2;
+    %load/vec4 v0x1a996f0_0;
+    %pushi/vec4 49, 0, 8;
+    %and;
+    %xor/r;
+    %inv;
+    %concat/vec4; draw_concat_vec4
+    %pad/u 8;
+    %assign/vec4 v0x1a996f0_0, 0;
+T_0.5 ;
+T_0.2 ;
+T_0.1 ;
+    %jmp T_0;
+    .thread T_0;
+    .scope S_0x1a84680;
+T_1 ;
+    %vpi_call 2 11 "$monitor", "rst %b en %b updown %b cnt %b overflow %b", v0x1a99fc0_0, v0x1a99df0_0, v0x1a9a060_0, v0x1a99d20_0, v0x1a99ef0_0 {0 0 0};
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x1a99c60_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x1a99fc0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x1a99df0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x1a9a060_0, 0, 1;
+    %delay 10, 0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x1a99fc0_0, 0, 1;
+    %delay 1, 0;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x1a99df0_0, 0, 1;
+    %delay 20, 0;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x1a9a060_0, 0, 1;
+    %delay 30, 0;
+    %vpi_call 2 20 "$finish" {0 0 0};
+    %end;
+    .thread T_1;
+    .scope S_0x1a84680;
+T_2 ;
+    %delay 1, 0;
+    %load/vec4 v0x1a99c60_0;
+    %inv;
+    %store/vec4 v0x1a99c60_0, 0, 1;
+    %jmp T_2;
+    .thread T_2;
+# The file index is used to find the file name in the following table.
+:file_names 4;
+    "N/A";
+    "<interactive>";
+    "lfsr_updown_tb.v";
+    "lfsr_updown.v";

--- a/examples/intel/asicworld_lfsr/run_cycloneiv
+++ b/examples/intel/asicworld_lfsr/run_cycloneiv
@@ -1,0 +1,1 @@
+yosys -p "synth_intel -family cycloneiv -top lfsr_updown -vout top.vqm" lfsr_updown.v

--- a/examples/intel/asicworld_lfsr/run_max10
+++ b/examples/intel/asicworld_lfsr/run_max10
@@ -1,0 +1,1 @@
+yosys -p "synth_intel -family max10 -top lfsr_updown -vout top.vqm" lfsr_updown.v

--- a/examples/intel/asicworld_lfsr/runme_postsynth
+++ b/examples/intel/asicworld_lfsr/runme_postsynth
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+iverilog -D POST_IMPL -o verif_post -s tb lfsr_updown_tb.v top.vqm $(yosys-config --datdir/altera_intel/max10/cells_comb_max10.v)
+vvp -N verif_post
+

--- a/examples/intel/asicworld_lfsr/runme_presynth
+++ b/examples/intel/asicworld_lfsr/runme_presynth
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+iverilog -o presynth lfsr_updown_tb.v lfsr_updown.v &&\
+
+vvp -N presynth

--- a/examples/intel/asicworld_lfsr/verif_post
+++ b/examples/intel/asicworld_lfsr/verif_post
@@ -1,0 +1,6525 @@
+#! /usr/local/bin/vvp
+:ivl_version "11.0 (devel)" "(s20150603-462-gfbd69e1-dirty)";
+:ivl_delay_selection "TYPICAL";
+:vpi_time_precision + 0;
+:vpi_module "system";
+:vpi_module "vhdl_sys";
+:vpi_module "vhdl_textio";
+:vpi_module "v2005_math";
+:vpi_module "va_math";
+S_0x24219d0 .scope module, "tb" "tb" 2 1;
+ .timescale 0 0;
+v0x2487700_0 .var "clk", 0 0;
+v0x2487810_0 .net "count", 7 0, L_0x2492d00;  1 drivers
+v0x24878d0_0 .var "enable", 0 0;
+v0x24879c0_0 .net "overflow", 0 0, L_0x24934d0;  1 drivers
+v0x2487ab0_0 .var "reset", 0 0;
+v0x2487bf0_0 .var "up_down", 0 0;
+S_0x243bc60 .scope module, "U" "lfsr_updown" 2 25, 3 5 0, S_0x24219d0;
+ .timescale 0 0;
+    .port_info 0 /INPUT 1 "clk"
+    .port_info 1 /INPUT 1 "reset"
+    .port_info 2 /INPUT 1 "enable"
+    .port_info 3 /INPUT 1 "up_down"
+    .port_info 4 /OUTPUT 8 "count"
+    .port_info 5 /OUTPUT 1 "overflow"
+L_0x7f14f87ade70 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+L_0x2491610 .functor BUFT 1, L_0x7f14f87ade70, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87adeb8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x24918f0 .functor BUFT 1, L_0x7f14f87adeb8, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87adf00 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2491470 .functor BUFT 1, L_0x7f14f87adf00, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87adf48 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2491ec0 .functor BUFT 1, L_0x7f14f87adf48, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87adf90 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2491bd0 .functor BUFT 1, L_0x7f14f87adf90, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87adfd8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x24924a0 .functor BUFT 1, L_0x7f14f87adfd8, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ae020 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x24921a0 .functor BUFT 1, L_0x7f14f87ae020, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ae068 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2492a90 .functor BUFT 1, L_0x7f14f87ae068, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ae0b0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2492870 .functor BUFT 1, L_0x7f14f87ae0b0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ae0f8 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+L_0x24933b0 .functor BUFT 1, L_0x7f14f87ae0f8, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ae140 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2493640 .functor BUFT 1, L_0x7f14f87ae140, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ae188 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+L_0x24937e0 .functor BUFT 1, L_0x7f14f87ae188, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ae1d0 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+L_0x2493a40 .functor BUFT 1, L_0x7f14f87ae1d0, C4<0>, C4<0>, C4<0>;
+v0x24854a0_0 .net/2u *"_s105", 0 0, L_0x7f14f87ade70;  1 drivers
+v0x24855a0_0 .net/2u *"_s113", 0 0, L_0x7f14f87adeb8;  1 drivers
+v0x2485680_0 .net/2u *"_s121", 0 0, L_0x7f14f87adf00;  1 drivers
+v0x2485740_0 .net/2u *"_s129", 0 0, L_0x7f14f87adf48;  1 drivers
+v0x2485820_0 .net/2u *"_s137", 0 0, L_0x7f14f87adf90;  1 drivers
+v0x2485900_0 .net/2u *"_s145", 0 0, L_0x7f14f87adfd8;  1 drivers
+v0x24859e0_0 .net/2u *"_s153", 0 0, L_0x7f14f87ae020;  1 drivers
+v0x2485ac0_0 .net/2u *"_s161", 0 0, L_0x7f14f87ae068;  1 drivers
+v0x2485ba0_0 .net/2u *"_s170", 0 0, L_0x7f14f87ae0b0;  1 drivers
+v0x2485d10_0 .net/2u *"_s174", 0 0, L_0x7f14f87ae0f8;  1 drivers
+v0x2485df0_0 .net/2u *"_s178", 0 0, L_0x7f14f87ae140;  1 drivers
+v0x2485ed0_0 .net/2u *"_s182", 0 0, L_0x7f14f87ae188;  1 drivers
+v0x2485fb0_0 .net/2u *"_s186", 0 0, L_0x7f14f87ae1d0;  1 drivers
+v0x2486090_0 .net "clk", 0 0, v0x2487700_0;  1 drivers
+v0x2486130_0 .net "count", 7 0, L_0x2492d00;  alias, 1 drivers
+v0x24861f0_0 .net "enable", 0 0, v0x24878d0_0;  1 drivers
+v0x2486290_0 .net "overflow", 0 0, L_0x24934d0;  alias, 1 drivers
+v0x2486440_0 .net "reset", 0 0, v0x2487ab0_0;  1 drivers
+v0x24864e0_0 .net "up_down", 0 0, v0x2487bf0_0;  1 drivers
+v0x2486580_0 .net "yosys__00_", 7 0, L_0x2491100;  1 drivers
+v0x2486620_0 .net "yosys__01_", 0 0, L_0x2487ea0;  1 drivers
+v0x24866c0_0 .net "yosys__02_", 0 0, L_0x2488bd0;  1 drivers
+v0x24867b0_0 .net "yosys__03_", 0 0, L_0x24898d0;  1 drivers
+v0x24868a0_0 .net "yosys__04_", 0 0, L_0x248a730;  1 drivers
+v0x2486990_0 .net "yosys__05_", 0 0, L_0x248b4e0;  1 drivers
+v0x2486a80_0 .net "yosys__06_", 0 0, L_0x248c5e0;  1 drivers
+v0x2486b70_0 .net "yosys__07_", 0 0, L_0x248d320;  1 drivers
+v0x2486c60_0 .net "yosys__08_", 0 0, L_0x248dba0;  1 drivers
+v0x2486d50_0 .net "yosys__09_", 0 0, L_0x248e450;  1 drivers
+v0x2486e40_0 .net "yosys__10_", 0 0, L_0x248f330;  1 drivers
+v0x2486f30_0 .net "yosys__11_", 0 0, L_0x248f970;  1 drivers
+v0x2487020_0 .net "yosys__12_", 0 0, L_0x2490840;  1 drivers
+v0x2487110_0 .net "yosys__13_", 0 0, L_0x24915a0;  1 drivers
+v0x2486330_0 .net "yosys__14_", 7 0, L_0x2494590;  1 drivers
+v0x24873c0_0 .net "yosys__15_", 0 0, L_0x2493340;  1 drivers
+v0x2487460_0 .net "yosys__16_", 0 0, L_0x248ed00;  1 drivers
+v0x2487500_0 .net "yosys__17_", 0 0, L_0x2493770;  1 drivers
+v0x24875a0_0 .net "yosys__18_", 0 0, L_0x24939d0;  1 drivers
+L_0x2487fd0 .part L_0x2494590, 2, 1;
+L_0x24880c0 .part L_0x2494590, 3, 1;
+L_0x2488200 .part L_0x2494590, 4, 1;
+L_0x2488740 .part L_0x2494590, 1, 1;
+L_0x2488e10 .part L_0x2494590, 2, 1;
+L_0x2488f00 .part L_0x2494590, 0, 1;
+L_0x2489500 .part L_0x2494590, 2, 1;
+L_0x2489b60 .part L_0x2494590, 3, 1;
+L_0x2489d60 .part L_0x2494590, 1, 1;
+L_0x248a2d0 .part L_0x2494590, 3, 1;
+L_0x248a9d0 .part L_0x2494590, 4, 1;
+L_0x248aac0 .part L_0x2494590, 2, 1;
+L_0x248b110 .part L_0x2494590, 4, 1;
+L_0x248b770 .part L_0x2494590, 5, 1;
+L_0x248b8e0 .part L_0x2494590, 3, 1;
+L_0x248bf60 .part L_0x2494590, 5, 1;
+L_0x248c830 .part L_0x2494590, 6, 1;
+L_0x248c920 .part L_0x2494590, 4, 1;
+L_0x248cf50 .part L_0x2494590, 6, 1;
+L_0x248d5b0 .part L_0x2494590, 7, 1;
+L_0x248ca10 .part L_0x2494590, 5, 1;
+L_0x248ddf0 .part L_0x2494590, 0, 1;
+L_0x248d6a0 .part L_0x2494590, 1, 1;
+L_0x248dff0 .part L_0x2494590, 5, 1;
+L_0x248dee0 .part L_0x2494590, 6, 1;
+L_0x248e6a0 .part L_0x2494590, 6, 1;
+L_0x248e0e0 .part L_0x2494590, 0, 1;
+L_0x248e8c0 .part L_0x2494590, 7, 1;
+L_0x248eeb0 .part L_0x2494590, 1, 1;
+L_0x248efa0 .part L_0x2494590, 5, 1;
+L_0x248f580 .part L_0x2494590, 0, 1;
+L_0x248fbc0 .part L_0x2494590, 1, 1;
+L_0x248c160 .part L_0x2494590, 4, 1;
+L_0x248f090 .part L_0x2494590, 5, 1;
+L_0x2490a90 .part L_0x2494590, 7, 1;
+LS_0x2491100_0_0 .concat8 [ 1 1 1 1], L_0x247de10, L_0x2488500, L_0x24892d0, L_0x248a090;
+LS_0x2491100_0_4 .concat8 [ 1 1 1 1], L_0x248ae90, L_0x24780d0, L_0x248ccd0, L_0x2490f20;
+L_0x2491100 .concat8 [ 4 4 0 0], LS_0x2491100_0_0, LS_0x2491100_0_4;
+L_0x2491800 .part L_0x2494590, 0, 1;
+L_0x2491ae0 .part L_0x2494590, 1, 1;
+L_0x2491dd0 .part L_0x2494590, 2, 1;
+L_0x24920b0 .part L_0x2494590, 3, 1;
+L_0x24923b0 .part L_0x2494590, 4, 1;
+L_0x2492690 .part L_0x2494590, 5, 1;
+L_0x24929a0 .part L_0x2494590, 6, 1;
+LS_0x2492d00_0_0 .concat8 [ 1 1 1 1], L_0x24916d0, L_0x24919b0, L_0x2491530, L_0x2491f80;
+LS_0x2492d00_0_4 .concat8 [ 1 1 1 1], L_0x2491c90, L_0x2492560, L_0x2492260, L_0x2492ba0;
+L_0x2492d00 .concat8 [ 4 4 0 0], LS_0x2492d00_0_0, LS_0x2492d00_0_4;
+L_0x2492780 .part L_0x2494590, 7, 1;
+L_0x2493b00 .part L_0x2491100, 0, 1;
+L_0x24930c0 .part L_0x2491100, 1, 1;
+L_0x248d7f0 .part L_0x2491100, 2, 1;
+L_0x2493c20 .part L_0x2491100, 3, 1;
+L_0x2494400 .part L_0x2491100, 4, 1;
+L_0x2494670 .part L_0x2491100, 5, 1;
+L_0x2494860 .part L_0x2491100, 6, 1;
+LS_0x2494590_0_0 .concat8 [ 1 1 1 1], v0x247edd0_0, v0x247fc30_0, v0x2480a10_0, v0x2481830_0;
+LS_0x2494590_0_4 .concat8 [ 1 1 1 1], v0x2482610_0, v0x24833f0_0, v0x24841d0_0, v0x2485030_0;
+L_0x2494590 .concat8 [ 4 4 0 0], LS_0x2494590_0_0, LS_0x2494590_0_4;
+L_0x2494d40 .part L_0x2491100, 7, 1;
+S_0x23b9a90 .scope module, "yosys__19_" "fiftyfivenm_lcell_comb" 3 39, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2445680 .param/str "dont_touch" 0 4 34, "off";
+P_0x24456c0 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x2445700 .param/l "lut_mask" 0 4 32, C4<0000000100000001>;
+P_0x2445740 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x2487ce0 .functor BUFZ 1, L_0x2487fd0, C4<0>, C4<0>, C4<0>;
+L_0x2487d50 .functor BUFZ 1, L_0x24880c0, C4<0>, C4<0>, C4<0>;
+L_0x2487dc0 .functor BUFZ 1, L_0x2488200, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad0a8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2487e30 .functor BUFZ 1, L_0x7f14f87ad0a8, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad018 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2487ea0 .functor AND 1, v0x23b6990_0, L_0x7f14f87ad018, C4<1>, C4<1>;
+L_0x7f14f87ad060 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2487f10 .functor AND 1, v0x23b7be0_0, L_0x7f14f87ad060, C4<1>, C4<1>;
+v0x23bea00_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad060;  1 drivers
+v0x23be120_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad018;  1 drivers
+o0x7f14f87f6198 .functor BUFZ 1, C4<z>; HiZ drive
+v0x23be200_0 .net "cin", 0 0, o0x7f14f87f6198;  0 drivers
+o0x7f14f87f61c8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x23b6d50_0 .net "cin_w", 0 0, o0x7f14f87f61c8;  0 drivers
+v0x23b6df0_0 .net "combout", 0 0, L_0x2487ea0;  alias, 1 drivers
+v0x23b6990_0 .var "combout_rt", 0 0;
+v0x23b6a50_0 .net "cout", 0 0, L_0x2487f10;  1 drivers
+v0x23b7be0_0 .var "cout_rt", 0 0;
+v0x23b7c80_0 .net "dataa", 0 0, L_0x2487fd0;  1 drivers
+v0x23b7490_0 .net "dataa_w", 0 0, L_0x2487ce0;  1 drivers
+v0x244ba10_0 .net "datab", 0 0, L_0x24880c0;  1 drivers
+v0x244bad0_0 .net "datab_w", 0 0, L_0x2487d50;  1 drivers
+v0x240df20_0 .net "datac", 0 0, L_0x2488200;  1 drivers
+v0x240dfe0_0 .net "datac_w", 0 0, L_0x2487dc0;  1 drivers
+v0x240db40_0 .net "datad", 0 0, L_0x7f14f87ad0a8;  1 drivers
+v0x240dc00_0 .net "datad_w", 0 0, L_0x2487e30;  1 drivers
+v0x2407260_0 .var "lut_type", 1 0;
+E_0x2446170/0 .event edge, v0x23b6d50_0, v0x240dc00_0, v0x240dfe0_0, v0x244bad0_0;
+E_0x2446170/1 .event edge, v0x23b7490_0;
+E_0x2446170 .event/or E_0x2446170/0, E_0x2446170/1;
+S_0x2447330 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x23b9a90;
+ .timescale 0 0;
+v0x2452050_0 .var "dataa", 0 0;
+v0x23bdb90_0 .var "datab", 0 0;
+v0x23bd6f0_0 .var "datac", 0 0;
+v0x23bd7c0_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x2447330
+v0x23be920_0 .var "mask", 15 0;
+TD_tb.U.yosys__19_.lut_data ;
+    %load/vec4 v0x23bd7c0_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_0.0, 8;
+    %load/vec4 v0x23bd6f0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_0.2, 9;
+    %load/vec4 v0x23bdb90_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_0.4, 10;
+    %load/vec4 v0x2452050_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_0.6, 11;
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_0.7, 11;
+T_0.6 ; End of true expr.
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_0.7, 11;
+ ; End of false expr.
+    %blend;
+T_0.7;
+    %jmp/1 T_0.5, 10;
+T_0.4 ; End of true expr.
+    %load/vec4 v0x2452050_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_0.8, 11;
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_0.9, 11;
+T_0.8 ; End of true expr.
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_0.9, 11;
+ ; End of false expr.
+    %blend;
+T_0.9;
+    %jmp/0 T_0.5, 10;
+ ; End of false expr.
+    %blend;
+T_0.5;
+    %jmp/1 T_0.3, 9;
+T_0.2 ; End of true expr.
+    %load/vec4 v0x23bdb90_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_0.10, 10;
+    %load/vec4 v0x2452050_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_0.12, 11;
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_0.13, 11;
+T_0.12 ; End of true expr.
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_0.13, 11;
+ ; End of false expr.
+    %blend;
+T_0.13;
+    %jmp/1 T_0.11, 10;
+T_0.10 ; End of true expr.
+    %load/vec4 v0x2452050_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_0.14, 11;
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_0.15, 11;
+T_0.14 ; End of true expr.
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_0.15, 11;
+ ; End of false expr.
+    %blend;
+T_0.15;
+    %jmp/0 T_0.11, 10;
+ ; End of false expr.
+    %blend;
+T_0.11;
+    %jmp/0 T_0.3, 9;
+ ; End of false expr.
+    %blend;
+T_0.3;
+    %jmp/1 T_0.1, 8;
+T_0.0 ; End of true expr.
+    %load/vec4 v0x23bd6f0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_0.16, 9;
+    %load/vec4 v0x23bdb90_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_0.18, 10;
+    %load/vec4 v0x2452050_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_0.20, 11;
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_0.21, 11;
+T_0.20 ; End of true expr.
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_0.21, 11;
+ ; End of false expr.
+    %blend;
+T_0.21;
+    %jmp/1 T_0.19, 10;
+T_0.18 ; End of true expr.
+    %load/vec4 v0x2452050_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_0.22, 11;
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_0.23, 11;
+T_0.22 ; End of true expr.
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_0.23, 11;
+ ; End of false expr.
+    %blend;
+T_0.23;
+    %jmp/0 T_0.19, 10;
+ ; End of false expr.
+    %blend;
+T_0.19;
+    %jmp/1 T_0.17, 9;
+T_0.16 ; End of true expr.
+    %load/vec4 v0x23bdb90_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_0.24, 10;
+    %load/vec4 v0x2452050_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_0.26, 11;
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_0.27, 11;
+T_0.26 ; End of true expr.
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_0.27, 11;
+ ; End of false expr.
+    %blend;
+T_0.27;
+    %jmp/1 T_0.25, 10;
+T_0.24 ; End of true expr.
+    %load/vec4 v0x2452050_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_0.28, 11;
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_0.29, 11;
+T_0.28 ; End of true expr.
+    %load/vec4 v0x23be920_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_0.29, 11;
+ ; End of false expr.
+    %blend;
+T_0.29;
+    %jmp/0 T_0.25, 10;
+ ; End of false expr.
+    %blend;
+T_0.25;
+    %jmp/0 T_0.17, 9;
+ ; End of false expr.
+    %blend;
+T_0.17;
+    %jmp/0 T_0.1, 8;
+ ; End of false expr.
+    %blend;
+T_0.1;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x23ed6e0 .scope module, "yosys__20_" "fiftyfivenm_lcell_comb" 3 49, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2459f20 .param/str "dont_touch" 0 4 34, "off";
+P_0x2459f60 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x2459fa0 .param/l "lut_mask" 0 4 32, C4<0000001100001010>;
+P_0x2459fe0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x2488340 .functor BUFZ 1, L_0x2488740, C4<0>, C4<0>, C4<0>;
+L_0x24883b0 .functor BUFZ 1, L_0x2488bd0, C4<0>, C4<0>, C4<0>;
+L_0x2488420 .functor BUFZ 1, L_0x2493770, C4<0>, C4<0>, C4<0>;
+L_0x2488490 .functor BUFZ 1, L_0x2493340, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad0f0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2488500 .functor AND 1, v0x2452ab0_0, L_0x7f14f87ad0f0, C4<1>, C4<1>;
+L_0x7f14f87ad138 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2488610 .functor AND 1, v0x2450670_0, L_0x7f14f87ad138, C4<1>, C4<1>;
+v0x2454cd0_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad138;  1 drivers
+v0x2454dd0_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad0f0;  1 drivers
+o0x7f14f87f6738 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2454eb0_0 .net "cin", 0 0, o0x7f14f87f6738;  0 drivers
+o0x7f14f87f6768 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2454f50_0 .net "cin_w", 0 0, o0x7f14f87f6768;  0 drivers
+v0x24529a0_0 .net "combout", 0 0, L_0x2488500;  1 drivers
+v0x2452ab0_0 .var "combout_rt", 0 0;
+v0x2452b70_0 .net "cout", 0 0, L_0x2488610;  1 drivers
+v0x2450670_0 .var "cout_rt", 0 0;
+v0x2450730_0 .net "dataa", 0 0, L_0x2488740;  1 drivers
+v0x24507f0_0 .net "dataa_w", 0 0, L_0x2488340;  1 drivers
+v0x24508b0_0 .net "datab", 0 0, L_0x2488bd0;  alias, 1 drivers
+v0x244e340_0 .net "datab_w", 0 0, L_0x24883b0;  1 drivers
+v0x244e3e0_0 .net "datac", 0 0, L_0x2493770;  alias, 1 drivers
+v0x244e4a0_0 .net "datac_w", 0 0, L_0x2488420;  1 drivers
+v0x244e560_0 .net "datad", 0 0, L_0x2493340;  alias, 1 drivers
+v0x244c010_0 .net "datad_w", 0 0, L_0x2488490;  1 drivers
+v0x244c0d0_0 .var "lut_type", 1 0;
+E_0x243aee0/0 .event edge, v0x2454f50_0, v0x244c010_0, v0x244e4a0_0, v0x244e340_0;
+E_0x243aee0/1 .event edge, v0x24507f0_0;
+E_0x243aee0 .event/or E_0x243aee0/0, E_0x243aee0/1;
+S_0x243e710 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x23ed6e0;
+ .timescale 0 0;
+v0x242e630_0 .var "dataa", 0 0;
+v0x23d3c40_0 .var "datab", 0 0;
+v0x2457000_0 .var "datac", 0 0;
+v0x24570a0_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x243e710
+v0x2457270_0 .var "mask", 15 0;
+TD_tb.U.yosys__20_.lut_data ;
+    %load/vec4 v0x24570a0_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_1.30, 8;
+    %load/vec4 v0x2457000_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_1.32, 9;
+    %load/vec4 v0x23d3c40_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_1.34, 10;
+    %load/vec4 v0x242e630_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_1.36, 11;
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_1.37, 11;
+T_1.36 ; End of true expr.
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_1.37, 11;
+ ; End of false expr.
+    %blend;
+T_1.37;
+    %jmp/1 T_1.35, 10;
+T_1.34 ; End of true expr.
+    %load/vec4 v0x242e630_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_1.38, 11;
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_1.39, 11;
+T_1.38 ; End of true expr.
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_1.39, 11;
+ ; End of false expr.
+    %blend;
+T_1.39;
+    %jmp/0 T_1.35, 10;
+ ; End of false expr.
+    %blend;
+T_1.35;
+    %jmp/1 T_1.33, 9;
+T_1.32 ; End of true expr.
+    %load/vec4 v0x23d3c40_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_1.40, 10;
+    %load/vec4 v0x242e630_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_1.42, 11;
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_1.43, 11;
+T_1.42 ; End of true expr.
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_1.43, 11;
+ ; End of false expr.
+    %blend;
+T_1.43;
+    %jmp/1 T_1.41, 10;
+T_1.40 ; End of true expr.
+    %load/vec4 v0x242e630_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_1.44, 11;
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_1.45, 11;
+T_1.44 ; End of true expr.
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_1.45, 11;
+ ; End of false expr.
+    %blend;
+T_1.45;
+    %jmp/0 T_1.41, 10;
+ ; End of false expr.
+    %blend;
+T_1.41;
+    %jmp/0 T_1.33, 9;
+ ; End of false expr.
+    %blend;
+T_1.33;
+    %jmp/1 T_1.31, 8;
+T_1.30 ; End of true expr.
+    %load/vec4 v0x2457000_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_1.46, 9;
+    %load/vec4 v0x23d3c40_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_1.48, 10;
+    %load/vec4 v0x242e630_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_1.50, 11;
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_1.51, 11;
+T_1.50 ; End of true expr.
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_1.51, 11;
+ ; End of false expr.
+    %blend;
+T_1.51;
+    %jmp/1 T_1.49, 10;
+T_1.48 ; End of true expr.
+    %load/vec4 v0x242e630_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_1.52, 11;
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_1.53, 11;
+T_1.52 ; End of true expr.
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_1.53, 11;
+ ; End of false expr.
+    %blend;
+T_1.53;
+    %jmp/0 T_1.49, 10;
+ ; End of false expr.
+    %blend;
+T_1.49;
+    %jmp/1 T_1.47, 9;
+T_1.46 ; End of true expr.
+    %load/vec4 v0x23d3c40_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_1.54, 10;
+    %load/vec4 v0x242e630_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_1.56, 11;
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_1.57, 11;
+T_1.56 ; End of true expr.
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_1.57, 11;
+ ; End of false expr.
+    %blend;
+T_1.57;
+    %jmp/1 T_1.55, 10;
+T_1.54 ; End of true expr.
+    %load/vec4 v0x242e630_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_1.58, 11;
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_1.59, 11;
+T_1.58 ; End of true expr.
+    %load/vec4 v0x2457270_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_1.59, 11;
+ ; End of false expr.
+    %blend;
+T_1.59;
+    %jmp/0 T_1.55, 10;
+ ; End of false expr.
+    %blend;
+T_1.55;
+    %jmp/0 T_1.47, 9;
+ ; End of false expr.
+    %blend;
+T_1.47;
+    %jmp/0 T_1.31, 8;
+ ; End of false expr.
+    %blend;
+T_1.31;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x2449ce0 .scope module, "yosys__21_" "fiftyfivenm_lcell_comb" 3 59, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2449e70 .param/str "dont_touch" 0 4 34, "off";
+P_0x2449eb0 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x2449ef0 .param/l "lut_mask" 0 4 32, C4<0101001101010011>;
+P_0x2449f30 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x24888c0 .functor BUFZ 1, L_0x2488e10, C4<0>, C4<0>, C4<0>;
+L_0x2488930 .functor BUFZ 1, L_0x2488f00, C4<0>, C4<0>, C4<0>;
+L_0x2488a00 .functor BUFZ 1, L_0x24939d0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad210 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2488aa0 .functor BUFZ 1, L_0x7f14f87ad210, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad180 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2488bd0 .functor AND 1, v0x243ac00_0, L_0x7f14f87ad180, C4<1>, C4<1>;
+L_0x7f14f87ad1c8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2488d00 .functor AND 1, v0x243ad40_0, L_0x7f14f87ad1c8, C4<1>, C4<1>;
+v0x23c71a0_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad1c8;  1 drivers
+v0x23c7280_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad180;  1 drivers
+o0x7f14f87f6cd8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x23c7360_0 .net "cin", 0 0, o0x7f14f87f6cd8;  0 drivers
+o0x7f14f87f6d08 .functor BUFZ 1, C4<z>; HiZ drive
+v0x23c7400_0 .net "cin_w", 0 0, o0x7f14f87f6d08;  0 drivers
+v0x243ab10_0 .net "combout", 0 0, L_0x2488bd0;  alias, 1 drivers
+v0x243ac00_0 .var "combout_rt", 0 0;
+v0x243aca0_0 .net "cout", 0 0, L_0x2488d00;  1 drivers
+v0x243ad40_0 .var "cout_rt", 0 0;
+v0x235c720_0 .net "dataa", 0 0, L_0x2488e10;  1 drivers
+v0x235c870_0 .net "dataa_w", 0 0, L_0x24888c0;  1 drivers
+v0x235c930_0 .net "datab", 0 0, L_0x2488f00;  1 drivers
+v0x235c9f0_0 .net "datab_w", 0 0, L_0x2488930;  1 drivers
+v0x235c040_0 .net "datac", 0 0, L_0x24939d0;  alias, 1 drivers
+v0x235c100_0 .net "datac_w", 0 0, L_0x2488a00;  1 drivers
+v0x235c1c0_0 .net "datad", 0 0, L_0x7f14f87ad210;  1 drivers
+v0x235c280_0 .net "datad_w", 0 0, L_0x2488aa0;  1 drivers
+v0x235c340_0 .var "lut_type", 1 0;
+E_0x23b7430/0 .event edge, v0x23c7400_0, v0x235c280_0, v0x235c100_0, v0x235c9f0_0;
+E_0x23b7430/1 .event edge, v0x235c870_0;
+E_0x23b7430 .event/or E_0x23b7430/0, E_0x23b7430/1;
+S_0x23edac0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x2449ce0;
+ .timescale 0 0;
+v0x23edcc0_0 .var "dataa", 0 0;
+v0x24078d0_0 .var "datab", 0 0;
+v0x23d3f50_0 .var "datac", 0 0;
+v0x23d3ff0_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x23edac0
+v0x23d41c0_0 .var "mask", 15 0;
+TD_tb.U.yosys__21_.lut_data ;
+    %load/vec4 v0x23d3ff0_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_2.60, 8;
+    %load/vec4 v0x23d3f50_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_2.62, 9;
+    %load/vec4 v0x24078d0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_2.64, 10;
+    %load/vec4 v0x23edcc0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_2.66, 11;
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_2.67, 11;
+T_2.66 ; End of true expr.
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_2.67, 11;
+ ; End of false expr.
+    %blend;
+T_2.67;
+    %jmp/1 T_2.65, 10;
+T_2.64 ; End of true expr.
+    %load/vec4 v0x23edcc0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_2.68, 11;
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_2.69, 11;
+T_2.68 ; End of true expr.
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_2.69, 11;
+ ; End of false expr.
+    %blend;
+T_2.69;
+    %jmp/0 T_2.65, 10;
+ ; End of false expr.
+    %blend;
+T_2.65;
+    %jmp/1 T_2.63, 9;
+T_2.62 ; End of true expr.
+    %load/vec4 v0x24078d0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_2.70, 10;
+    %load/vec4 v0x23edcc0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_2.72, 11;
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_2.73, 11;
+T_2.72 ; End of true expr.
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_2.73, 11;
+ ; End of false expr.
+    %blend;
+T_2.73;
+    %jmp/1 T_2.71, 10;
+T_2.70 ; End of true expr.
+    %load/vec4 v0x23edcc0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_2.74, 11;
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_2.75, 11;
+T_2.74 ; End of true expr.
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_2.75, 11;
+ ; End of false expr.
+    %blend;
+T_2.75;
+    %jmp/0 T_2.71, 10;
+ ; End of false expr.
+    %blend;
+T_2.71;
+    %jmp/0 T_2.63, 9;
+ ; End of false expr.
+    %blend;
+T_2.63;
+    %jmp/1 T_2.61, 8;
+T_2.60 ; End of true expr.
+    %load/vec4 v0x23d3f50_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_2.76, 9;
+    %load/vec4 v0x24078d0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_2.78, 10;
+    %load/vec4 v0x23edcc0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_2.80, 11;
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_2.81, 11;
+T_2.80 ; End of true expr.
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_2.81, 11;
+ ; End of false expr.
+    %blend;
+T_2.81;
+    %jmp/1 T_2.79, 10;
+T_2.78 ; End of true expr.
+    %load/vec4 v0x23edcc0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_2.82, 11;
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_2.83, 11;
+T_2.82 ; End of true expr.
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_2.83, 11;
+ ; End of false expr.
+    %blend;
+T_2.83;
+    %jmp/0 T_2.79, 10;
+ ; End of false expr.
+    %blend;
+T_2.79;
+    %jmp/1 T_2.77, 9;
+T_2.76 ; End of true expr.
+    %load/vec4 v0x24078d0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_2.84, 10;
+    %load/vec4 v0x23edcc0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_2.86, 11;
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_2.87, 11;
+T_2.86 ; End of true expr.
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_2.87, 11;
+ ; End of false expr.
+    %blend;
+T_2.87;
+    %jmp/1 T_2.85, 10;
+T_2.84 ; End of true expr.
+    %load/vec4 v0x23edcc0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_2.88, 11;
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_2.89, 11;
+T_2.88 ; End of true expr.
+    %load/vec4 v0x23d41c0_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_2.89, 11;
+ ; End of false expr.
+    %blend;
+T_2.89;
+    %jmp/0 T_2.85, 10;
+ ; End of false expr.
+    %blend;
+T_2.85;
+    %jmp/0 T_2.77, 9;
+ ; End of false expr.
+    %blend;
+T_2.77;
+    %jmp/0 T_2.61, 8;
+ ; End of false expr.
+    %blend;
+T_2.61;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x23671c0 .scope module, "yosys__22_" "fiftyfivenm_lcell_comb" 3 69, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2367350 .param/str "dont_touch" 0 4 34, "off";
+P_0x2367390 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x23673d0 .param/l "lut_mask" 0 4 32, C4<0000001100001010>;
+P_0x2367410 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x2489080 .functor BUFZ 1, L_0x2489500, C4<0>, C4<0>, C4<0>;
+L_0x24890f0 .functor BUFZ 1, L_0x24898d0, C4<0>, C4<0>, C4<0>;
+L_0x2489160 .functor BUFZ 1, L_0x2493770, C4<0>, C4<0>, C4<0>;
+L_0x24891d0 .functor BUFZ 1, L_0x2493340, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad258 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x24892d0 .functor AND 1, v0x23449e0_0, L_0x7f14f87ad258, C4<1>, C4<1>;
+L_0x7f14f87ad2a0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x24893a0 .functor AND 1, v0x2341950_0, L_0x7f14f87ad2a0, C4<1>, C4<1>;
+v0x235ecc0_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad2a0;  1 drivers
+v0x2344690_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad258;  1 drivers
+o0x7f14f87f7248 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2344770_0 .net "cin", 0 0, o0x7f14f87f7248;  0 drivers
+o0x7f14f87f7278 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2344810_0 .net "cin_w", 0 0, o0x7f14f87f7278;  0 drivers
+v0x23448d0_0 .net "combout", 0 0, L_0x24892d0;  1 drivers
+v0x23449e0_0 .var "combout_rt", 0 0;
+v0x2341890_0 .net "cout", 0 0, L_0x24893a0;  1 drivers
+v0x2341950_0 .var "cout_rt", 0 0;
+v0x2341a10_0 .net "dataa", 0 0, L_0x2489500;  1 drivers
+v0x2341ad0_0 .net "dataa_w", 0 0, L_0x2489080;  1 drivers
+v0x2341b90_0 .net "datab", 0 0, L_0x24898d0;  alias, 1 drivers
+v0x245bae0_0 .net "datab_w", 0 0, L_0x24890f0;  1 drivers
+v0x245bb80_0 .net "datac", 0 0, L_0x2493770;  alias, 1 drivers
+v0x245bc20_0 .net "datac_w", 0 0, L_0x2489160;  1 drivers
+v0x245bcc0_0 .net "datad", 0 0, L_0x2493340;  alias, 1 drivers
+v0x245bd60_0 .net "datad_w", 0 0, L_0x24891d0;  1 drivers
+v0x245be00_0 .var "lut_type", 1 0;
+E_0x24076c0/0 .event edge, v0x2344810_0, v0x245bd60_0, v0x245bc20_0, v0x245bae0_0;
+E_0x24076c0/1 .event edge, v0x2341ad0_0;
+E_0x24076c0 .event/or E_0x24076c0/0, E_0x24076c0/1;
+S_0x235dca0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x23671c0;
+ .timescale 0 0;
+v0x235dea0_0 .var "dataa", 0 0;
+v0x235df80_0 .var "datab", 0 0;
+v0x235d1a0_0 .var "datac", 0 0;
+v0x235ea60_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x235dca0
+v0x235ebe0_0 .var "mask", 15 0;
+TD_tb.U.yosys__22_.lut_data ;
+    %load/vec4 v0x235ea60_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_3.90, 8;
+    %load/vec4 v0x235d1a0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_3.92, 9;
+    %load/vec4 v0x235df80_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_3.94, 10;
+    %load/vec4 v0x235dea0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_3.96, 11;
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_3.97, 11;
+T_3.96 ; End of true expr.
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_3.97, 11;
+ ; End of false expr.
+    %blend;
+T_3.97;
+    %jmp/1 T_3.95, 10;
+T_3.94 ; End of true expr.
+    %load/vec4 v0x235dea0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_3.98, 11;
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_3.99, 11;
+T_3.98 ; End of true expr.
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_3.99, 11;
+ ; End of false expr.
+    %blend;
+T_3.99;
+    %jmp/0 T_3.95, 10;
+ ; End of false expr.
+    %blend;
+T_3.95;
+    %jmp/1 T_3.93, 9;
+T_3.92 ; End of true expr.
+    %load/vec4 v0x235df80_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_3.100, 10;
+    %load/vec4 v0x235dea0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_3.102, 11;
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_3.103, 11;
+T_3.102 ; End of true expr.
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_3.103, 11;
+ ; End of false expr.
+    %blend;
+T_3.103;
+    %jmp/1 T_3.101, 10;
+T_3.100 ; End of true expr.
+    %load/vec4 v0x235dea0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_3.104, 11;
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_3.105, 11;
+T_3.104 ; End of true expr.
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_3.105, 11;
+ ; End of false expr.
+    %blend;
+T_3.105;
+    %jmp/0 T_3.101, 10;
+ ; End of false expr.
+    %blend;
+T_3.101;
+    %jmp/0 T_3.93, 9;
+ ; End of false expr.
+    %blend;
+T_3.93;
+    %jmp/1 T_3.91, 8;
+T_3.90 ; End of true expr.
+    %load/vec4 v0x235d1a0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_3.106, 9;
+    %load/vec4 v0x235df80_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_3.108, 10;
+    %load/vec4 v0x235dea0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_3.110, 11;
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_3.111, 11;
+T_3.110 ; End of true expr.
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_3.111, 11;
+ ; End of false expr.
+    %blend;
+T_3.111;
+    %jmp/1 T_3.109, 10;
+T_3.108 ; End of true expr.
+    %load/vec4 v0x235dea0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_3.112, 11;
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_3.113, 11;
+T_3.112 ; End of true expr.
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_3.113, 11;
+ ; End of false expr.
+    %blend;
+T_3.113;
+    %jmp/0 T_3.109, 10;
+ ; End of false expr.
+    %blend;
+T_3.109;
+    %jmp/1 T_3.107, 9;
+T_3.106 ; End of true expr.
+    %load/vec4 v0x235df80_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_3.114, 10;
+    %load/vec4 v0x235dea0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_3.116, 11;
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_3.117, 11;
+T_3.116 ; End of true expr.
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_3.117, 11;
+ ; End of false expr.
+    %blend;
+T_3.117;
+    %jmp/1 T_3.115, 10;
+T_3.114 ; End of true expr.
+    %load/vec4 v0x235dea0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_3.118, 11;
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_3.119, 11;
+T_3.118 ; End of true expr.
+    %load/vec4 v0x235ebe0_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_3.119, 11;
+ ; End of false expr.
+    %blend;
+T_3.119;
+    %jmp/0 T_3.115, 10;
+ ; End of false expr.
+    %blend;
+T_3.115;
+    %jmp/0 T_3.107, 9;
+ ; End of false expr.
+    %blend;
+T_3.107;
+    %jmp/0 T_3.91, 8;
+ ; End of false expr.
+    %blend;
+T_3.91;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x245c050 .scope module, "yosys__23_" "fiftyfivenm_lcell_comb" 3 79, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x245c230 .param/str "dont_touch" 0 4 34, "off";
+P_0x245c270 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x245c2b0 .param/l "lut_mask" 0 4 32, C4<0101001101010011>;
+P_0x245c2f0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x24895f0 .functor BUFZ 1, L_0x2489b60, C4<0>, C4<0>, C4<0>;
+L_0x2489660 .functor BUFZ 1, L_0x2489d60, C4<0>, C4<0>, C4<0>;
+L_0x2489700 .functor BUFZ 1, L_0x24939d0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad378 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x24897a0 .functor BUFZ 1, L_0x7f14f87ad378, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad2e8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x24898d0 .functor AND 1, v0x245d160_0, L_0x7f14f87ad2e8, C4<1>, C4<1>;
+L_0x7f14f87ad330 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2489a00 .functor AND 1, v0x245d2c0_0, L_0x7f14f87ad330, C4<1>, C4<1>;
+v0x245cd30_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad330;  1 drivers
+v0x245ce30_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad2e8;  1 drivers
+o0x7f14f87f7788 .functor BUFZ 1, C4<z>; HiZ drive
+v0x245cf10_0 .net "cin", 0 0, o0x7f14f87f7788;  0 drivers
+o0x7f14f87f77b8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x245cfb0_0 .net "cin_w", 0 0, o0x7f14f87f77b8;  0 drivers
+v0x245d070_0 .net "combout", 0 0, L_0x24898d0;  alias, 1 drivers
+v0x245d160_0 .var "combout_rt", 0 0;
+v0x245d200_0 .net "cout", 0 0, L_0x2489a00;  1 drivers
+v0x245d2c0_0 .var "cout_rt", 0 0;
+v0x245d380_0 .net "dataa", 0 0, L_0x2489b60;  1 drivers
+v0x245d4d0_0 .net "dataa_w", 0 0, L_0x24895f0;  1 drivers
+v0x245d590_0 .net "datab", 0 0, L_0x2489d60;  1 drivers
+v0x245d650_0 .net "datab_w", 0 0, L_0x2489660;  1 drivers
+v0x245d710_0 .net "datac", 0 0, L_0x24939d0;  alias, 1 drivers
+v0x245d7e0_0 .net "datac_w", 0 0, L_0x2489700;  1 drivers
+v0x245d880_0 .net "datad", 0 0, L_0x7f14f87ad378;  1 drivers
+v0x245d940_0 .net "datad_w", 0 0, L_0x24897a0;  1 drivers
+v0x245da00_0 .var "lut_type", 1 0;
+E_0x2367460/0 .event edge, v0x245cfb0_0, v0x245d940_0, v0x245d7e0_0, v0x245d650_0;
+E_0x2367460/1 .event edge, v0x245d4d0_0;
+E_0x2367460 .event/or E_0x2367460/0, E_0x2367460/1;
+S_0x245c640 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x245c050;
+ .timescale 0 0;
+v0x245c840_0 .var "dataa", 0 0;
+v0x245c920_0 .var "datab", 0 0;
+v0x245c9e0_0 .var "datac", 0 0;
+v0x245ca80_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x245c640
+v0x245cc50_0 .var "mask", 15 0;
+TD_tb.U.yosys__23_.lut_data ;
+    %load/vec4 v0x245ca80_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_4.120, 8;
+    %load/vec4 v0x245c9e0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_4.122, 9;
+    %load/vec4 v0x245c920_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_4.124, 10;
+    %load/vec4 v0x245c840_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_4.126, 11;
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_4.127, 11;
+T_4.126 ; End of true expr.
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_4.127, 11;
+ ; End of false expr.
+    %blend;
+T_4.127;
+    %jmp/1 T_4.125, 10;
+T_4.124 ; End of true expr.
+    %load/vec4 v0x245c840_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_4.128, 11;
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_4.129, 11;
+T_4.128 ; End of true expr.
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_4.129, 11;
+ ; End of false expr.
+    %blend;
+T_4.129;
+    %jmp/0 T_4.125, 10;
+ ; End of false expr.
+    %blend;
+T_4.125;
+    %jmp/1 T_4.123, 9;
+T_4.122 ; End of true expr.
+    %load/vec4 v0x245c920_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_4.130, 10;
+    %load/vec4 v0x245c840_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_4.132, 11;
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_4.133, 11;
+T_4.132 ; End of true expr.
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_4.133, 11;
+ ; End of false expr.
+    %blend;
+T_4.133;
+    %jmp/1 T_4.131, 10;
+T_4.130 ; End of true expr.
+    %load/vec4 v0x245c840_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_4.134, 11;
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_4.135, 11;
+T_4.134 ; End of true expr.
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_4.135, 11;
+ ; End of false expr.
+    %blend;
+T_4.135;
+    %jmp/0 T_4.131, 10;
+ ; End of false expr.
+    %blend;
+T_4.131;
+    %jmp/0 T_4.123, 9;
+ ; End of false expr.
+    %blend;
+T_4.123;
+    %jmp/1 T_4.121, 8;
+T_4.120 ; End of true expr.
+    %load/vec4 v0x245c9e0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_4.136, 9;
+    %load/vec4 v0x245c920_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_4.138, 10;
+    %load/vec4 v0x245c840_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_4.140, 11;
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_4.141, 11;
+T_4.140 ; End of true expr.
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_4.141, 11;
+ ; End of false expr.
+    %blend;
+T_4.141;
+    %jmp/1 T_4.139, 10;
+T_4.138 ; End of true expr.
+    %load/vec4 v0x245c840_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_4.142, 11;
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_4.143, 11;
+T_4.142 ; End of true expr.
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_4.143, 11;
+ ; End of false expr.
+    %blend;
+T_4.143;
+    %jmp/0 T_4.139, 10;
+ ; End of false expr.
+    %blend;
+T_4.139;
+    %jmp/1 T_4.137, 9;
+T_4.136 ; End of true expr.
+    %load/vec4 v0x245c920_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_4.144, 10;
+    %load/vec4 v0x245c840_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_4.146, 11;
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_4.147, 11;
+T_4.146 ; End of true expr.
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_4.147, 11;
+ ; End of false expr.
+    %blend;
+T_4.147;
+    %jmp/1 T_4.145, 10;
+T_4.144 ; End of true expr.
+    %load/vec4 v0x245c840_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_4.148, 11;
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_4.149, 11;
+T_4.148 ; End of true expr.
+    %load/vec4 v0x245cc50_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_4.149, 11;
+ ; End of false expr.
+    %blend;
+T_4.149;
+    %jmp/0 T_4.145, 10;
+ ; End of false expr.
+    %blend;
+T_4.145;
+    %jmp/0 T_4.137, 9;
+ ; End of false expr.
+    %blend;
+T_4.137;
+    %jmp/0 T_4.121, 8;
+ ; End of false expr.
+    %blend;
+T_4.121;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x245dc90 .scope module, "yosys__24_" "fiftyfivenm_lcell_comb" 3 89, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x245de20 .param/str "dont_touch" 0 4 34, "off";
+P_0x245de60 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x245dea0 .param/l "lut_mask" 0 4 32, C4<0000001100001010>;
+P_0x245dee0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x2489ea0 .functor BUFZ 1, L_0x248a2d0, C4<0>, C4<0>, C4<0>;
+L_0x2489f10 .functor BUFZ 1, L_0x248a730, C4<0>, C4<0>, C4<0>;
+L_0x2489f80 .functor BUFZ 1, L_0x2493770, C4<0>, C4<0>, C4<0>;
+L_0x2489ff0 .functor BUFZ 1, L_0x2493340, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad3c0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248a090 .functor AND 1, v0x245eda0_0, L_0x7f14f87ad3c0, C4<1>, C4<1>;
+L_0x7f14f87ad408 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248a1b0 .functor AND 1, v0x245ef20_0, L_0x7f14f87ad408, C4<1>, C4<1>;
+v0x245e950_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad408;  1 drivers
+v0x245ea50_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad3c0;  1 drivers
+o0x7f14f87f7cc8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x245eb30_0 .net "cin", 0 0, o0x7f14f87f7cc8;  0 drivers
+o0x7f14f87f7cf8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x245ebd0_0 .net "cin_w", 0 0, o0x7f14f87f7cf8;  0 drivers
+v0x245ec90_0 .net "combout", 0 0, L_0x248a090;  1 drivers
+v0x245eda0_0 .var "combout_rt", 0 0;
+v0x245ee60_0 .net "cout", 0 0, L_0x248a1b0;  1 drivers
+v0x245ef20_0 .var "cout_rt", 0 0;
+v0x245efe0_0 .net "dataa", 0 0, L_0x248a2d0;  1 drivers
+v0x245f130_0 .net "dataa_w", 0 0, L_0x2489ea0;  1 drivers
+v0x245f1f0_0 .net "datab", 0 0, L_0x248a730;  alias, 1 drivers
+v0x245f2b0_0 .net "datab_w", 0 0, L_0x2489f10;  1 drivers
+v0x245f370_0 .net "datac", 0 0, L_0x2493770;  alias, 1 drivers
+v0x245f410_0 .net "datac_w", 0 0, L_0x2489f80;  1 drivers
+v0x245f4d0_0 .net "datad", 0 0, L_0x2493340;  alias, 1 drivers
+v0x245f5c0_0 .net "datad_w", 0 0, L_0x2489ff0;  1 drivers
+v0x245f680_0 .var "lut_type", 1 0;
+E_0x245c430/0 .event edge, v0x245ebd0_0, v0x245f5c0_0, v0x245f410_0, v0x245f2b0_0;
+E_0x245c430/1 .event edge, v0x245f130_0;
+E_0x245c430 .event/or E_0x245c430/0, E_0x245c430/1;
+S_0x245e260 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x245dc90;
+ .timescale 0 0;
+v0x245e460_0 .var "dataa", 0 0;
+v0x245e540_0 .var "datab", 0 0;
+v0x245e600_0 .var "datac", 0 0;
+v0x245e6a0_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x245e260
+v0x245e870_0 .var "mask", 15 0;
+TD_tb.U.yosys__24_.lut_data ;
+    %load/vec4 v0x245e6a0_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_5.150, 8;
+    %load/vec4 v0x245e600_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_5.152, 9;
+    %load/vec4 v0x245e540_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_5.154, 10;
+    %load/vec4 v0x245e460_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_5.156, 11;
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_5.157, 11;
+T_5.156 ; End of true expr.
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_5.157, 11;
+ ; End of false expr.
+    %blend;
+T_5.157;
+    %jmp/1 T_5.155, 10;
+T_5.154 ; End of true expr.
+    %load/vec4 v0x245e460_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_5.158, 11;
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_5.159, 11;
+T_5.158 ; End of true expr.
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_5.159, 11;
+ ; End of false expr.
+    %blend;
+T_5.159;
+    %jmp/0 T_5.155, 10;
+ ; End of false expr.
+    %blend;
+T_5.155;
+    %jmp/1 T_5.153, 9;
+T_5.152 ; End of true expr.
+    %load/vec4 v0x245e540_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_5.160, 10;
+    %load/vec4 v0x245e460_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_5.162, 11;
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_5.163, 11;
+T_5.162 ; End of true expr.
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_5.163, 11;
+ ; End of false expr.
+    %blend;
+T_5.163;
+    %jmp/1 T_5.161, 10;
+T_5.160 ; End of true expr.
+    %load/vec4 v0x245e460_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_5.164, 11;
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_5.165, 11;
+T_5.164 ; End of true expr.
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_5.165, 11;
+ ; End of false expr.
+    %blend;
+T_5.165;
+    %jmp/0 T_5.161, 10;
+ ; End of false expr.
+    %blend;
+T_5.161;
+    %jmp/0 T_5.153, 9;
+ ; End of false expr.
+    %blend;
+T_5.153;
+    %jmp/1 T_5.151, 8;
+T_5.150 ; End of true expr.
+    %load/vec4 v0x245e600_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_5.166, 9;
+    %load/vec4 v0x245e540_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_5.168, 10;
+    %load/vec4 v0x245e460_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_5.170, 11;
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_5.171, 11;
+T_5.170 ; End of true expr.
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_5.171, 11;
+ ; End of false expr.
+    %blend;
+T_5.171;
+    %jmp/1 T_5.169, 10;
+T_5.168 ; End of true expr.
+    %load/vec4 v0x245e460_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_5.172, 11;
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_5.173, 11;
+T_5.172 ; End of true expr.
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_5.173, 11;
+ ; End of false expr.
+    %blend;
+T_5.173;
+    %jmp/0 T_5.169, 10;
+ ; End of false expr.
+    %blend;
+T_5.169;
+    %jmp/1 T_5.167, 9;
+T_5.166 ; End of true expr.
+    %load/vec4 v0x245e540_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_5.174, 10;
+    %load/vec4 v0x245e460_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_5.176, 11;
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_5.177, 11;
+T_5.176 ; End of true expr.
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_5.177, 11;
+ ; End of false expr.
+    %blend;
+T_5.177;
+    %jmp/1 T_5.175, 10;
+T_5.174 ; End of true expr.
+    %load/vec4 v0x245e460_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_5.178, 11;
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_5.179, 11;
+T_5.178 ; End of true expr.
+    %load/vec4 v0x245e870_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_5.179, 11;
+ ; End of false expr.
+    %blend;
+T_5.179;
+    %jmp/0 T_5.175, 10;
+ ; End of false expr.
+    %blend;
+T_5.175;
+    %jmp/0 T_5.167, 9;
+ ; End of false expr.
+    %blend;
+T_5.167;
+    %jmp/0 T_5.151, 8;
+ ; End of false expr.
+    %blend;
+T_5.151;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x245f910 .scope module, "yosys__25_" "fiftyfivenm_lcell_comb" 3 99, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x245faf0 .param/str "dont_touch" 0 4 34, "off";
+P_0x245fb30 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x245fb70 .param/l "lut_mask" 0 4 32, C4<0101001101010011>;
+P_0x245fbb0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248a420 .functor BUFZ 1, L_0x248a9d0, C4<0>, C4<0>, C4<0>;
+L_0x248a490 .functor BUFZ 1, L_0x248aac0, C4<0>, C4<0>, C4<0>;
+L_0x248a560 .functor BUFZ 1, L_0x24939d0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad4e0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248a600 .functor BUFZ 1, L_0x7f14f87ad4e0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad450 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248a730 .functor AND 1, v0x24609f0_0, L_0x7f14f87ad450, C4<1>, C4<1>;
+L_0x7f14f87ad498 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2489240 .functor AND 1, v0x2460b50_0, L_0x7f14f87ad498, C4<1>, C4<1>;
+v0x24605c0_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad498;  1 drivers
+v0x24606c0_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad450;  1 drivers
+o0x7f14f87f8208 .functor BUFZ 1, C4<z>; HiZ drive
+v0x24607a0_0 .net "cin", 0 0, o0x7f14f87f8208;  0 drivers
+o0x7f14f87f8238 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2460840_0 .net "cin_w", 0 0, o0x7f14f87f8238;  0 drivers
+v0x2460900_0 .net "combout", 0 0, L_0x248a730;  alias, 1 drivers
+v0x24609f0_0 .var "combout_rt", 0 0;
+v0x2460a90_0 .net "cout", 0 0, L_0x2489240;  1 drivers
+v0x2460b50_0 .var "cout_rt", 0 0;
+v0x2460c10_0 .net "dataa", 0 0, L_0x248a9d0;  1 drivers
+v0x2460d60_0 .net "dataa_w", 0 0, L_0x248a420;  1 drivers
+v0x2460e20_0 .net "datab", 0 0, L_0x248aac0;  1 drivers
+v0x2460ee0_0 .net "datab_w", 0 0, L_0x248a490;  1 drivers
+v0x2460fa0_0 .net "datac", 0 0, L_0x24939d0;  alias, 1 drivers
+v0x2461040_0 .net "datac_w", 0 0, L_0x248a560;  1 drivers
+v0x2461100_0 .net "datad", 0 0, L_0x7f14f87ad4e0;  1 drivers
+v0x24611c0_0 .net "datad_w", 0 0, L_0x248a600;  1 drivers
+v0x2461280_0 .var "lut_type", 1 0;
+E_0x245e050/0 .event edge, v0x2460840_0, v0x24611c0_0, v0x2461040_0, v0x2460ee0_0;
+E_0x245e050/1 .event edge, v0x2460d60_0;
+E_0x245e050 .event/or E_0x245e050/0, E_0x245e050/1;
+S_0x245fed0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x245f910;
+ .timescale 0 0;
+v0x24600d0_0 .var "dataa", 0 0;
+v0x24601b0_0 .var "datab", 0 0;
+v0x2460270_0 .var "datac", 0 0;
+v0x2460310_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x245fed0
+v0x24604e0_0 .var "mask", 15 0;
+TD_tb.U.yosys__25_.lut_data ;
+    %load/vec4 v0x2460310_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_6.180, 8;
+    %load/vec4 v0x2460270_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_6.182, 9;
+    %load/vec4 v0x24601b0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_6.184, 10;
+    %load/vec4 v0x24600d0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_6.186, 11;
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_6.187, 11;
+T_6.186 ; End of true expr.
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_6.187, 11;
+ ; End of false expr.
+    %blend;
+T_6.187;
+    %jmp/1 T_6.185, 10;
+T_6.184 ; End of true expr.
+    %load/vec4 v0x24600d0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_6.188, 11;
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_6.189, 11;
+T_6.188 ; End of true expr.
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_6.189, 11;
+ ; End of false expr.
+    %blend;
+T_6.189;
+    %jmp/0 T_6.185, 10;
+ ; End of false expr.
+    %blend;
+T_6.185;
+    %jmp/1 T_6.183, 9;
+T_6.182 ; End of true expr.
+    %load/vec4 v0x24601b0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_6.190, 10;
+    %load/vec4 v0x24600d0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_6.192, 11;
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_6.193, 11;
+T_6.192 ; End of true expr.
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_6.193, 11;
+ ; End of false expr.
+    %blend;
+T_6.193;
+    %jmp/1 T_6.191, 10;
+T_6.190 ; End of true expr.
+    %load/vec4 v0x24600d0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_6.194, 11;
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_6.195, 11;
+T_6.194 ; End of true expr.
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_6.195, 11;
+ ; End of false expr.
+    %blend;
+T_6.195;
+    %jmp/0 T_6.191, 10;
+ ; End of false expr.
+    %blend;
+T_6.191;
+    %jmp/0 T_6.183, 9;
+ ; End of false expr.
+    %blend;
+T_6.183;
+    %jmp/1 T_6.181, 8;
+T_6.180 ; End of true expr.
+    %load/vec4 v0x2460270_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_6.196, 9;
+    %load/vec4 v0x24601b0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_6.198, 10;
+    %load/vec4 v0x24600d0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_6.200, 11;
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_6.201, 11;
+T_6.200 ; End of true expr.
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_6.201, 11;
+ ; End of false expr.
+    %blend;
+T_6.201;
+    %jmp/1 T_6.199, 10;
+T_6.198 ; End of true expr.
+    %load/vec4 v0x24600d0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_6.202, 11;
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_6.203, 11;
+T_6.202 ; End of true expr.
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_6.203, 11;
+ ; End of false expr.
+    %blend;
+T_6.203;
+    %jmp/0 T_6.199, 10;
+ ; End of false expr.
+    %blend;
+T_6.199;
+    %jmp/1 T_6.197, 9;
+T_6.196 ; End of true expr.
+    %load/vec4 v0x24601b0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_6.204, 10;
+    %load/vec4 v0x24600d0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_6.206, 11;
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_6.207, 11;
+T_6.206 ; End of true expr.
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_6.207, 11;
+ ; End of false expr.
+    %blend;
+T_6.207;
+    %jmp/1 T_6.205, 10;
+T_6.204 ; End of true expr.
+    %load/vec4 v0x24600d0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_6.208, 11;
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_6.209, 11;
+T_6.208 ; End of true expr.
+    %load/vec4 v0x24604e0_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_6.209, 11;
+ ; End of false expr.
+    %blend;
+T_6.209;
+    %jmp/0 T_6.205, 10;
+ ; End of false expr.
+    %blend;
+T_6.205;
+    %jmp/0 T_6.197, 9;
+ ; End of false expr.
+    %blend;
+T_6.197;
+    %jmp/0 T_6.181, 8;
+ ; End of false expr.
+    %blend;
+T_6.181;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x2461510 .scope module, "yosys__26_" "fiftyfivenm_lcell_comb" 3 109, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x24616f0 .param/str "dont_touch" 0 4 34, "off";
+P_0x2461730 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x2461770 .param/l "lut_mask" 0 4 32, C4<0000001100001010>;
+P_0x24617b0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248ac70 .functor BUFZ 1, L_0x248b110, C4<0>, C4<0>, C4<0>;
+L_0x248ace0 .functor BUFZ 1, L_0x248b4e0, C4<0>, C4<0>, C4<0>;
+L_0x248ad50 .functor BUFZ 1, L_0x2493770, C4<0>, C4<0>, C4<0>;
+L_0x248adc0 .functor BUFZ 1, L_0x2493340, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad528 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248ae90 .functor AND 1, v0x2462610_0, L_0x7f14f87ad528, C4<1>, C4<1>;
+L_0x7f14f87ad570 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248afb0 .functor AND 1, v0x2462790_0, L_0x7f14f87ad570, C4<1>, C4<1>;
+v0x24621c0_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad570;  1 drivers
+v0x24622c0_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad528;  1 drivers
+o0x7f14f87f8748 .functor BUFZ 1, C4<z>; HiZ drive
+v0x24623a0_0 .net "cin", 0 0, o0x7f14f87f8748;  0 drivers
+o0x7f14f87f8778 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2462440_0 .net "cin_w", 0 0, o0x7f14f87f8778;  0 drivers
+v0x2462500_0 .net "combout", 0 0, L_0x248ae90;  1 drivers
+v0x2462610_0 .var "combout_rt", 0 0;
+v0x24626d0_0 .net "cout", 0 0, L_0x248afb0;  1 drivers
+v0x2462790_0 .var "cout_rt", 0 0;
+v0x2462850_0 .net "dataa", 0 0, L_0x248b110;  1 drivers
+v0x24629a0_0 .net "dataa_w", 0 0, L_0x248ac70;  1 drivers
+v0x2462a60_0 .net "datab", 0 0, L_0x248b4e0;  alias, 1 drivers
+v0x2462b20_0 .net "datab_w", 0 0, L_0x248ace0;  1 drivers
+v0x2462be0_0 .net "datac", 0 0, L_0x2493770;  alias, 1 drivers
+v0x2462c80_0 .net "datac_w", 0 0, L_0x248ad50;  1 drivers
+v0x2462d40_0 .net "datad", 0 0, L_0x2493340;  alias, 1 drivers
+v0x2462de0_0 .net "datad_w", 0 0, L_0x248adc0;  1 drivers
+v0x2462ea0_0 .var "lut_type", 1 0;
+E_0x245fcc0/0 .event edge, v0x2462440_0, v0x2462de0_0, v0x2462c80_0, v0x2462b20_0;
+E_0x245fcc0/1 .event edge, v0x24629a0_0;
+E_0x245fcc0 .event/or E_0x245fcc0/0, E_0x245fcc0/1;
+S_0x2461ad0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x2461510;
+ .timescale 0 0;
+v0x2461cd0_0 .var "dataa", 0 0;
+v0x2461db0_0 .var "datab", 0 0;
+v0x2461e70_0 .var "datac", 0 0;
+v0x2461f10_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x2461ad0
+v0x24620e0_0 .var "mask", 15 0;
+TD_tb.U.yosys__26_.lut_data ;
+    %load/vec4 v0x2461f10_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_7.210, 8;
+    %load/vec4 v0x2461e70_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_7.212, 9;
+    %load/vec4 v0x2461db0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_7.214, 10;
+    %load/vec4 v0x2461cd0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_7.216, 11;
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_7.217, 11;
+T_7.216 ; End of true expr.
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_7.217, 11;
+ ; End of false expr.
+    %blend;
+T_7.217;
+    %jmp/1 T_7.215, 10;
+T_7.214 ; End of true expr.
+    %load/vec4 v0x2461cd0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_7.218, 11;
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_7.219, 11;
+T_7.218 ; End of true expr.
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_7.219, 11;
+ ; End of false expr.
+    %blend;
+T_7.219;
+    %jmp/0 T_7.215, 10;
+ ; End of false expr.
+    %blend;
+T_7.215;
+    %jmp/1 T_7.213, 9;
+T_7.212 ; End of true expr.
+    %load/vec4 v0x2461db0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_7.220, 10;
+    %load/vec4 v0x2461cd0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_7.222, 11;
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_7.223, 11;
+T_7.222 ; End of true expr.
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_7.223, 11;
+ ; End of false expr.
+    %blend;
+T_7.223;
+    %jmp/1 T_7.221, 10;
+T_7.220 ; End of true expr.
+    %load/vec4 v0x2461cd0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_7.224, 11;
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_7.225, 11;
+T_7.224 ; End of true expr.
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_7.225, 11;
+ ; End of false expr.
+    %blend;
+T_7.225;
+    %jmp/0 T_7.221, 10;
+ ; End of false expr.
+    %blend;
+T_7.221;
+    %jmp/0 T_7.213, 9;
+ ; End of false expr.
+    %blend;
+T_7.213;
+    %jmp/1 T_7.211, 8;
+T_7.210 ; End of true expr.
+    %load/vec4 v0x2461e70_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_7.226, 9;
+    %load/vec4 v0x2461db0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_7.228, 10;
+    %load/vec4 v0x2461cd0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_7.230, 11;
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_7.231, 11;
+T_7.230 ; End of true expr.
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_7.231, 11;
+ ; End of false expr.
+    %blend;
+T_7.231;
+    %jmp/1 T_7.229, 10;
+T_7.228 ; End of true expr.
+    %load/vec4 v0x2461cd0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_7.232, 11;
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_7.233, 11;
+T_7.232 ; End of true expr.
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_7.233, 11;
+ ; End of false expr.
+    %blend;
+T_7.233;
+    %jmp/0 T_7.229, 10;
+ ; End of false expr.
+    %blend;
+T_7.229;
+    %jmp/1 T_7.227, 9;
+T_7.226 ; End of true expr.
+    %load/vec4 v0x2461db0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_7.234, 10;
+    %load/vec4 v0x2461cd0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_7.236, 11;
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_7.237, 11;
+T_7.236 ; End of true expr.
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_7.237, 11;
+ ; End of false expr.
+    %blend;
+T_7.237;
+    %jmp/1 T_7.235, 10;
+T_7.234 ; End of true expr.
+    %load/vec4 v0x2461cd0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_7.238, 11;
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_7.239, 11;
+T_7.238 ; End of true expr.
+    %load/vec4 v0x24620e0_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_7.239, 11;
+ ; End of false expr.
+    %blend;
+T_7.239;
+    %jmp/0 T_7.235, 10;
+ ; End of false expr.
+    %blend;
+T_7.235;
+    %jmp/0 T_7.227, 9;
+ ; End of false expr.
+    %blend;
+T_7.227;
+    %jmp/0 T_7.211, 8;
+ ; End of false expr.
+    %blend;
+T_7.211;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x2463130 .scope module, "yosys__27_" "fiftyfivenm_lcell_comb" 3 119, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2463350 .param/str "dont_touch" 0 4 34, "off";
+P_0x2463390 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x24633d0 .param/l "lut_mask" 0 4 32, C4<0101001101010011>;
+P_0x2463410 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248b200 .functor BUFZ 1, L_0x248b770, C4<0>, C4<0>, C4<0>;
+L_0x248b270 .functor BUFZ 1, L_0x248b8e0, C4<0>, C4<0>, C4<0>;
+L_0x248b310 .functor BUFZ 1, L_0x24939d0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad648 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248b3b0 .functor BUFZ 1, L_0x7f14f87ad648, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad5b8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248b4e0 .functor AND 1, v0x2464230_0, L_0x7f14f87ad5b8, C4<1>, C4<1>;
+L_0x7f14f87ad600 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248b610 .functor AND 1, v0x2464390_0, L_0x7f14f87ad600, C4<1>, C4<1>;
+v0x2463e00_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad600;  1 drivers
+v0x2463f00_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad5b8;  1 drivers
+o0x7f14f87f8c88 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2463fe0_0 .net "cin", 0 0, o0x7f14f87f8c88;  0 drivers
+o0x7f14f87f8cb8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2464080_0 .net "cin_w", 0 0, o0x7f14f87f8cb8;  0 drivers
+v0x2464140_0 .net "combout", 0 0, L_0x248b4e0;  alias, 1 drivers
+v0x2464230_0 .var "combout_rt", 0 0;
+v0x24642d0_0 .net "cout", 0 0, L_0x248b610;  1 drivers
+v0x2464390_0 .var "cout_rt", 0 0;
+v0x2464450_0 .net "dataa", 0 0, L_0x248b770;  1 drivers
+v0x24645a0_0 .net "dataa_w", 0 0, L_0x248b200;  1 drivers
+v0x2464660_0 .net "datab", 0 0, L_0x248b8e0;  1 drivers
+v0x2464720_0 .net "datab_w", 0 0, L_0x248b270;  1 drivers
+v0x24647e0_0 .net "datac", 0 0, L_0x24939d0;  alias, 1 drivers
+v0x2464880_0 .net "datac_w", 0 0, L_0x248b310;  1 drivers
+v0x2464940_0 .net "datad", 0 0, L_0x7f14f87ad648;  1 drivers
+v0x2464a00_0 .net "datad_w", 0 0, L_0x248b3b0;  1 drivers
+v0x2464ac0_0 .var "lut_type", 1 0;
+E_0x24618c0/0 .event edge, v0x2464080_0, v0x2464a00_0, v0x2464880_0, v0x2464720_0;
+E_0x24618c0/1 .event edge, v0x24645a0_0;
+E_0x24618c0 .event/or E_0x24618c0/0, E_0x24618c0/1;
+S_0x2463710 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x2463130;
+ .timescale 0 0;
+v0x2463910_0 .var "dataa", 0 0;
+v0x24639f0_0 .var "datab", 0 0;
+v0x2463ab0_0 .var "datac", 0 0;
+v0x2463b50_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x2463710
+v0x2463d20_0 .var "mask", 15 0;
+TD_tb.U.yosys__27_.lut_data ;
+    %load/vec4 v0x2463b50_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_8.240, 8;
+    %load/vec4 v0x2463ab0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_8.242, 9;
+    %load/vec4 v0x24639f0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_8.244, 10;
+    %load/vec4 v0x2463910_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_8.246, 11;
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_8.247, 11;
+T_8.246 ; End of true expr.
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_8.247, 11;
+ ; End of false expr.
+    %blend;
+T_8.247;
+    %jmp/1 T_8.245, 10;
+T_8.244 ; End of true expr.
+    %load/vec4 v0x2463910_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_8.248, 11;
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_8.249, 11;
+T_8.248 ; End of true expr.
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_8.249, 11;
+ ; End of false expr.
+    %blend;
+T_8.249;
+    %jmp/0 T_8.245, 10;
+ ; End of false expr.
+    %blend;
+T_8.245;
+    %jmp/1 T_8.243, 9;
+T_8.242 ; End of true expr.
+    %load/vec4 v0x24639f0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_8.250, 10;
+    %load/vec4 v0x2463910_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_8.252, 11;
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_8.253, 11;
+T_8.252 ; End of true expr.
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_8.253, 11;
+ ; End of false expr.
+    %blend;
+T_8.253;
+    %jmp/1 T_8.251, 10;
+T_8.250 ; End of true expr.
+    %load/vec4 v0x2463910_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_8.254, 11;
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_8.255, 11;
+T_8.254 ; End of true expr.
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_8.255, 11;
+ ; End of false expr.
+    %blend;
+T_8.255;
+    %jmp/0 T_8.251, 10;
+ ; End of false expr.
+    %blend;
+T_8.251;
+    %jmp/0 T_8.243, 9;
+ ; End of false expr.
+    %blend;
+T_8.243;
+    %jmp/1 T_8.241, 8;
+T_8.240 ; End of true expr.
+    %load/vec4 v0x2463ab0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_8.256, 9;
+    %load/vec4 v0x24639f0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_8.258, 10;
+    %load/vec4 v0x2463910_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_8.260, 11;
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_8.261, 11;
+T_8.260 ; End of true expr.
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_8.261, 11;
+ ; End of false expr.
+    %blend;
+T_8.261;
+    %jmp/1 T_8.259, 10;
+T_8.258 ; End of true expr.
+    %load/vec4 v0x2463910_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_8.262, 11;
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_8.263, 11;
+T_8.262 ; End of true expr.
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_8.263, 11;
+ ; End of false expr.
+    %blend;
+T_8.263;
+    %jmp/0 T_8.259, 10;
+ ; End of false expr.
+    %blend;
+T_8.259;
+    %jmp/1 T_8.257, 9;
+T_8.256 ; End of true expr.
+    %load/vec4 v0x24639f0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_8.264, 10;
+    %load/vec4 v0x2463910_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_8.266, 11;
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_8.267, 11;
+T_8.266 ; End of true expr.
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_8.267, 11;
+ ; End of false expr.
+    %blend;
+T_8.267;
+    %jmp/1 T_8.265, 10;
+T_8.264 ; End of true expr.
+    %load/vec4 v0x2463910_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_8.268, 11;
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_8.269, 11;
+T_8.268 ; End of true expr.
+    %load/vec4 v0x2463d20_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_8.269, 11;
+ ; End of false expr.
+    %blend;
+T_8.269;
+    %jmp/0 T_8.265, 10;
+ ; End of false expr.
+    %blend;
+T_8.265;
+    %jmp/0 T_8.257, 9;
+ ; End of false expr.
+    %blend;
+T_8.257;
+    %jmp/0 T_8.241, 8;
+ ; End of false expr.
+    %blend;
+T_8.241;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x2464d50 .scope module, "yosys__28_" "fiftyfivenm_lcell_comb" 3 129, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2464ee0 .param/str "dont_touch" 0 4 34, "off";
+P_0x2464f20 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x2464f60 .param/l "lut_mask" 0 4 32, C4<0000001100001010>;
+P_0x2464fa0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248abb0 .functor BUFZ 1, L_0x248bf60, C4<0>, C4<0>, C4<0>;
+L_0x248ba20 .functor BUFZ 1, L_0x248c5e0, C4<0>, C4<0>, C4<0>;
+L_0x248ba90 .functor BUFZ 1, L_0x2493770, C4<0>, C4<0>, C4<0>;
+L_0x248bb00 .functor BUFZ 1, L_0x2493340, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad690 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x24780d0 .functor AND 1, v0x2465e60_0, L_0x7f14f87ad690, C4<1>, C4<1>;
+L_0x7f14f87ad6d8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248be00 .functor AND 1, v0x2465fe0_0, L_0x7f14f87ad6d8, C4<1>, C4<1>;
+v0x2465a10_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad6d8;  1 drivers
+v0x2465b10_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad690;  1 drivers
+o0x7f14f87f91c8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2465bf0_0 .net "cin", 0 0, o0x7f14f87f91c8;  0 drivers
+o0x7f14f87f91f8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2465c90_0 .net "cin_w", 0 0, o0x7f14f87f91f8;  0 drivers
+v0x2465d50_0 .net "combout", 0 0, L_0x24780d0;  1 drivers
+v0x2465e60_0 .var "combout_rt", 0 0;
+v0x2465f20_0 .net "cout", 0 0, L_0x248be00;  1 drivers
+v0x2465fe0_0 .var "cout_rt", 0 0;
+v0x24660a0_0 .net "dataa", 0 0, L_0x248bf60;  1 drivers
+v0x24661f0_0 .net "dataa_w", 0 0, L_0x248abb0;  1 drivers
+v0x24662b0_0 .net "datab", 0 0, L_0x248c5e0;  alias, 1 drivers
+v0x2466370_0 .net "datab_w", 0 0, L_0x248ba20;  1 drivers
+v0x2466430_0 .net "datac", 0 0, L_0x2493770;  alias, 1 drivers
+v0x2466560_0 .net "datac_w", 0 0, L_0x248ba90;  1 drivers
+v0x2466620_0 .net "datad", 0 0, L_0x2493340;  alias, 1 drivers
+v0x2466750_0 .net "datad_w", 0 0, L_0x248bb00;  1 drivers
+v0x2466810_0 .var "lut_type", 1 0;
+E_0x2463500/0 .event edge, v0x2465c90_0, v0x2466750_0, v0x2466560_0, v0x2466370_0;
+E_0x2463500/1 .event edge, v0x24661f0_0;
+E_0x2463500 .event/or E_0x2463500/0, E_0x2463500/1;
+S_0x2465320 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x2464d50;
+ .timescale 0 0;
+v0x2465520_0 .var "dataa", 0 0;
+v0x2465600_0 .var "datab", 0 0;
+v0x24656c0_0 .var "datac", 0 0;
+v0x2465760_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x2465320
+v0x2465930_0 .var "mask", 15 0;
+TD_tb.U.yosys__28_.lut_data ;
+    %load/vec4 v0x2465760_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_9.270, 8;
+    %load/vec4 v0x24656c0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_9.272, 9;
+    %load/vec4 v0x2465600_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_9.274, 10;
+    %load/vec4 v0x2465520_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_9.276, 11;
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_9.277, 11;
+T_9.276 ; End of true expr.
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_9.277, 11;
+ ; End of false expr.
+    %blend;
+T_9.277;
+    %jmp/1 T_9.275, 10;
+T_9.274 ; End of true expr.
+    %load/vec4 v0x2465520_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_9.278, 11;
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_9.279, 11;
+T_9.278 ; End of true expr.
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_9.279, 11;
+ ; End of false expr.
+    %blend;
+T_9.279;
+    %jmp/0 T_9.275, 10;
+ ; End of false expr.
+    %blend;
+T_9.275;
+    %jmp/1 T_9.273, 9;
+T_9.272 ; End of true expr.
+    %load/vec4 v0x2465600_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_9.280, 10;
+    %load/vec4 v0x2465520_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_9.282, 11;
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_9.283, 11;
+T_9.282 ; End of true expr.
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_9.283, 11;
+ ; End of false expr.
+    %blend;
+T_9.283;
+    %jmp/1 T_9.281, 10;
+T_9.280 ; End of true expr.
+    %load/vec4 v0x2465520_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_9.284, 11;
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_9.285, 11;
+T_9.284 ; End of true expr.
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_9.285, 11;
+ ; End of false expr.
+    %blend;
+T_9.285;
+    %jmp/0 T_9.281, 10;
+ ; End of false expr.
+    %blend;
+T_9.281;
+    %jmp/0 T_9.273, 9;
+ ; End of false expr.
+    %blend;
+T_9.273;
+    %jmp/1 T_9.271, 8;
+T_9.270 ; End of true expr.
+    %load/vec4 v0x24656c0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_9.286, 9;
+    %load/vec4 v0x2465600_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_9.288, 10;
+    %load/vec4 v0x2465520_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_9.290, 11;
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_9.291, 11;
+T_9.290 ; End of true expr.
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_9.291, 11;
+ ; End of false expr.
+    %blend;
+T_9.291;
+    %jmp/1 T_9.289, 10;
+T_9.288 ; End of true expr.
+    %load/vec4 v0x2465520_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_9.292, 11;
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_9.293, 11;
+T_9.292 ; End of true expr.
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_9.293, 11;
+ ; End of false expr.
+    %blend;
+T_9.293;
+    %jmp/0 T_9.289, 10;
+ ; End of false expr.
+    %blend;
+T_9.289;
+    %jmp/1 T_9.287, 9;
+T_9.286 ; End of true expr.
+    %load/vec4 v0x2465600_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_9.294, 10;
+    %load/vec4 v0x2465520_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_9.296, 11;
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_9.297, 11;
+T_9.296 ; End of true expr.
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_9.297, 11;
+ ; End of false expr.
+    %blend;
+T_9.297;
+    %jmp/1 T_9.295, 10;
+T_9.294 ; End of true expr.
+    %load/vec4 v0x2465520_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_9.298, 11;
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_9.299, 11;
+T_9.298 ; End of true expr.
+    %load/vec4 v0x2465930_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_9.299, 11;
+ ; End of false expr.
+    %blend;
+T_9.299;
+    %jmp/0 T_9.295, 10;
+ ; End of false expr.
+    %blend;
+T_9.295;
+    %jmp/0 T_9.287, 9;
+ ; End of false expr.
+    %blend;
+T_9.287;
+    %jmp/0 T_9.271, 8;
+ ; End of false expr.
+    %blend;
+T_9.271;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x2466aa0 .scope module, "yosys__29_" "fiftyfivenm_lcell_comb" 3 139, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2466c30 .param/str "dont_touch" 0 4 34, "off";
+P_0x2466c70 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x2466cb0 .param/l "lut_mask" 0 4 32, C4<0101001101010011>;
+P_0x2466cf0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x2489ce0 .functor BUFZ 1, L_0x248c830, C4<0>, C4<0>, C4<0>;
+L_0x248c260 .functor BUFZ 1, L_0x248c920, C4<0>, C4<0>, C4<0>;
+L_0x248c300 .functor BUFZ 1, L_0x24939d0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad7b0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2474820 .functor BUFZ 1, L_0x7f14f87ad7b0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad720 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248c5e0 .functor AND 1, v0x2467ac0_0, L_0x7f14f87ad720, C4<1>, C4<1>;
+L_0x7f14f87ad768 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248c710 .functor AND 1, v0x2467c20_0, L_0x7f14f87ad768, C4<1>, C4<1>;
+v0x2467690_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad768;  1 drivers
+v0x2467790_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad720;  1 drivers
+o0x7f14f87f9708 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2467870_0 .net "cin", 0 0, o0x7f14f87f9708;  0 drivers
+o0x7f14f87f9738 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2467910_0 .net "cin_w", 0 0, o0x7f14f87f9738;  0 drivers
+v0x24679d0_0 .net "combout", 0 0, L_0x248c5e0;  alias, 1 drivers
+v0x2467ac0_0 .var "combout_rt", 0 0;
+v0x2467b60_0 .net "cout", 0 0, L_0x248c710;  1 drivers
+v0x2467c20_0 .var "cout_rt", 0 0;
+v0x2467ce0_0 .net "dataa", 0 0, L_0x248c830;  1 drivers
+v0x2467e30_0 .net "dataa_w", 0 0, L_0x2489ce0;  1 drivers
+v0x2467ef0_0 .net "datab", 0 0, L_0x248c920;  1 drivers
+v0x2467fb0_0 .net "datab_w", 0 0, L_0x248c260;  1 drivers
+v0x2468070_0 .net "datac", 0 0, L_0x24939d0;  alias, 1 drivers
+v0x24681a0_0 .net "datac_w", 0 0, L_0x248c300;  1 drivers
+v0x2468260_0 .net "datad", 0 0, L_0x7f14f87ad7b0;  1 drivers
+v0x2468320_0 .net "datad_w", 0 0, L_0x2474820;  1 drivers
+v0x24683e0_0 .var "lut_type", 1 0;
+E_0x2465110/0 .event edge, v0x2467910_0, v0x2468320_0, v0x24681a0_0, v0x2467fb0_0;
+E_0x2465110/1 .event edge, v0x2467e30_0;
+E_0x2465110 .event/or E_0x2465110/0, E_0x2465110/1;
+S_0x2466fa0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x2466aa0;
+ .timescale 0 0;
+v0x24671a0_0 .var "dataa", 0 0;
+v0x2467280_0 .var "datab", 0 0;
+v0x2467340_0 .var "datac", 0 0;
+v0x24673e0_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x2466fa0
+v0x24675b0_0 .var "mask", 15 0;
+TD_tb.U.yosys__29_.lut_data ;
+    %load/vec4 v0x24673e0_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_10.300, 8;
+    %load/vec4 v0x2467340_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_10.302, 9;
+    %load/vec4 v0x2467280_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_10.304, 10;
+    %load/vec4 v0x24671a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_10.306, 11;
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_10.307, 11;
+T_10.306 ; End of true expr.
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_10.307, 11;
+ ; End of false expr.
+    %blend;
+T_10.307;
+    %jmp/1 T_10.305, 10;
+T_10.304 ; End of true expr.
+    %load/vec4 v0x24671a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_10.308, 11;
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_10.309, 11;
+T_10.308 ; End of true expr.
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_10.309, 11;
+ ; End of false expr.
+    %blend;
+T_10.309;
+    %jmp/0 T_10.305, 10;
+ ; End of false expr.
+    %blend;
+T_10.305;
+    %jmp/1 T_10.303, 9;
+T_10.302 ; End of true expr.
+    %load/vec4 v0x2467280_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_10.310, 10;
+    %load/vec4 v0x24671a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_10.312, 11;
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_10.313, 11;
+T_10.312 ; End of true expr.
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_10.313, 11;
+ ; End of false expr.
+    %blend;
+T_10.313;
+    %jmp/1 T_10.311, 10;
+T_10.310 ; End of true expr.
+    %load/vec4 v0x24671a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_10.314, 11;
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_10.315, 11;
+T_10.314 ; End of true expr.
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_10.315, 11;
+ ; End of false expr.
+    %blend;
+T_10.315;
+    %jmp/0 T_10.311, 10;
+ ; End of false expr.
+    %blend;
+T_10.311;
+    %jmp/0 T_10.303, 9;
+ ; End of false expr.
+    %blend;
+T_10.303;
+    %jmp/1 T_10.301, 8;
+T_10.300 ; End of true expr.
+    %load/vec4 v0x2467340_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_10.316, 9;
+    %load/vec4 v0x2467280_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_10.318, 10;
+    %load/vec4 v0x24671a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_10.320, 11;
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_10.321, 11;
+T_10.320 ; End of true expr.
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_10.321, 11;
+ ; End of false expr.
+    %blend;
+T_10.321;
+    %jmp/1 T_10.319, 10;
+T_10.318 ; End of true expr.
+    %load/vec4 v0x24671a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_10.322, 11;
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_10.323, 11;
+T_10.322 ; End of true expr.
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_10.323, 11;
+ ; End of false expr.
+    %blend;
+T_10.323;
+    %jmp/0 T_10.319, 10;
+ ; End of false expr.
+    %blend;
+T_10.319;
+    %jmp/1 T_10.317, 9;
+T_10.316 ; End of true expr.
+    %load/vec4 v0x2467280_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_10.324, 10;
+    %load/vec4 v0x24671a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_10.326, 11;
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_10.327, 11;
+T_10.326 ; End of true expr.
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_10.327, 11;
+ ; End of false expr.
+    %blend;
+T_10.327;
+    %jmp/1 T_10.325, 10;
+T_10.324 ; End of true expr.
+    %load/vec4 v0x24671a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_10.328, 11;
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_10.329, 11;
+T_10.328 ; End of true expr.
+    %load/vec4 v0x24675b0_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_10.329, 11;
+ ; End of false expr.
+    %blend;
+T_10.329;
+    %jmp/0 T_10.325, 10;
+ ; End of false expr.
+    %blend;
+T_10.325;
+    %jmp/0 T_10.317, 9;
+ ; End of false expr.
+    %blend;
+T_10.317;
+    %jmp/0 T_10.301, 8;
+ ; End of false expr.
+    %blend;
+T_10.301;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x2468670 .scope module, "yosys__30_" "fiftyfivenm_lcell_comb" 3 149, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2468800 .param/str "dont_touch" 0 4 34, "off";
+P_0x2468840 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x2468880 .param/l "lut_mask" 0 4 32, C4<0000001100001010>;
+P_0x24688c0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248cab0 .functor BUFZ 1, L_0x248cf50, C4<0>, C4<0>, C4<0>;
+L_0x248cb20 .functor BUFZ 1, L_0x248d320, C4<0>, C4<0>, C4<0>;
+L_0x248cb90 .functor BUFZ 1, L_0x2493770, C4<0>, C4<0>, C4<0>;
+L_0x248cc00 .functor BUFZ 1, L_0x2493340, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad7f8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248ccd0 .functor AND 1, v0x2469730_0, L_0x7f14f87ad7f8, C4<1>, C4<1>;
+L_0x7f14f87ad840 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248cdf0 .functor AND 1, v0x24698b0_0, L_0x7f14f87ad840, C4<1>, C4<1>;
+v0x24692e0_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad840;  1 drivers
+v0x24693e0_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad7f8;  1 drivers
+o0x7f14f87f9c48 .functor BUFZ 1, C4<z>; HiZ drive
+v0x24694c0_0 .net "cin", 0 0, o0x7f14f87f9c48;  0 drivers
+o0x7f14f87f9c78 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2469560_0 .net "cin_w", 0 0, o0x7f14f87f9c78;  0 drivers
+v0x2469620_0 .net "combout", 0 0, L_0x248ccd0;  1 drivers
+v0x2469730_0 .var "combout_rt", 0 0;
+v0x24697f0_0 .net "cout", 0 0, L_0x248cdf0;  1 drivers
+v0x24698b0_0 .var "cout_rt", 0 0;
+v0x2469970_0 .net "dataa", 0 0, L_0x248cf50;  1 drivers
+v0x2469ac0_0 .net "dataa_w", 0 0, L_0x248cab0;  1 drivers
+v0x2469b80_0 .net "datab", 0 0, L_0x248d320;  alias, 1 drivers
+v0x2469c40_0 .net "datab_w", 0 0, L_0x248cb20;  1 drivers
+v0x2469d00_0 .net "datac", 0 0, L_0x2493770;  alias, 1 drivers
+v0x2469da0_0 .net "datac_w", 0 0, L_0x248cb90;  1 drivers
+v0x2469e60_0 .net "datad", 0 0, L_0x2493340;  alias, 1 drivers
+v0x2469f00_0 .net "datad_w", 0 0, L_0x248cc00;  1 drivers
+v0x2469fc0_0 .var "lut_type", 1 0;
+E_0x2466d90/0 .event edge, v0x2469560_0, v0x2469f00_0, v0x2469da0_0, v0x2469c40_0;
+E_0x2466d90/1 .event edge, v0x2469ac0_0;
+E_0x2466d90 .event/or E_0x2466d90/0, E_0x2466d90/1;
+S_0x2468bf0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x2468670;
+ .timescale 0 0;
+v0x2468df0_0 .var "dataa", 0 0;
+v0x2468ed0_0 .var "datab", 0 0;
+v0x2468f90_0 .var "datac", 0 0;
+v0x2469030_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x2468bf0
+v0x2469200_0 .var "mask", 15 0;
+TD_tb.U.yosys__30_.lut_data ;
+    %load/vec4 v0x2469030_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_11.330, 8;
+    %load/vec4 v0x2468f90_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_11.332, 9;
+    %load/vec4 v0x2468ed0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_11.334, 10;
+    %load/vec4 v0x2468df0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_11.336, 11;
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_11.337, 11;
+T_11.336 ; End of true expr.
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_11.337, 11;
+ ; End of false expr.
+    %blend;
+T_11.337;
+    %jmp/1 T_11.335, 10;
+T_11.334 ; End of true expr.
+    %load/vec4 v0x2468df0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_11.338, 11;
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_11.339, 11;
+T_11.338 ; End of true expr.
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_11.339, 11;
+ ; End of false expr.
+    %blend;
+T_11.339;
+    %jmp/0 T_11.335, 10;
+ ; End of false expr.
+    %blend;
+T_11.335;
+    %jmp/1 T_11.333, 9;
+T_11.332 ; End of true expr.
+    %load/vec4 v0x2468ed0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_11.340, 10;
+    %load/vec4 v0x2468df0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_11.342, 11;
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_11.343, 11;
+T_11.342 ; End of true expr.
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_11.343, 11;
+ ; End of false expr.
+    %blend;
+T_11.343;
+    %jmp/1 T_11.341, 10;
+T_11.340 ; End of true expr.
+    %load/vec4 v0x2468df0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_11.344, 11;
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_11.345, 11;
+T_11.344 ; End of true expr.
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_11.345, 11;
+ ; End of false expr.
+    %blend;
+T_11.345;
+    %jmp/0 T_11.341, 10;
+ ; End of false expr.
+    %blend;
+T_11.341;
+    %jmp/0 T_11.333, 9;
+ ; End of false expr.
+    %blend;
+T_11.333;
+    %jmp/1 T_11.331, 8;
+T_11.330 ; End of true expr.
+    %load/vec4 v0x2468f90_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_11.346, 9;
+    %load/vec4 v0x2468ed0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_11.348, 10;
+    %load/vec4 v0x2468df0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_11.350, 11;
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_11.351, 11;
+T_11.350 ; End of true expr.
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_11.351, 11;
+ ; End of false expr.
+    %blend;
+T_11.351;
+    %jmp/1 T_11.349, 10;
+T_11.348 ; End of true expr.
+    %load/vec4 v0x2468df0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_11.352, 11;
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_11.353, 11;
+T_11.352 ; End of true expr.
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_11.353, 11;
+ ; End of false expr.
+    %blend;
+T_11.353;
+    %jmp/0 T_11.349, 10;
+ ; End of false expr.
+    %blend;
+T_11.349;
+    %jmp/1 T_11.347, 9;
+T_11.346 ; End of true expr.
+    %load/vec4 v0x2468ed0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_11.354, 10;
+    %load/vec4 v0x2468df0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_11.356, 11;
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_11.357, 11;
+T_11.356 ; End of true expr.
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_11.357, 11;
+ ; End of false expr.
+    %blend;
+T_11.357;
+    %jmp/1 T_11.355, 10;
+T_11.354 ; End of true expr.
+    %load/vec4 v0x2468df0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_11.358, 11;
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_11.359, 11;
+T_11.358 ; End of true expr.
+    %load/vec4 v0x2469200_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_11.359, 11;
+ ; End of false expr.
+    %blend;
+T_11.359;
+    %jmp/0 T_11.355, 10;
+ ; End of false expr.
+    %blend;
+T_11.355;
+    %jmp/0 T_11.347, 9;
+ ; End of false expr.
+    %blend;
+T_11.347;
+    %jmp/0 T_11.331, 8;
+ ; End of false expr.
+    %blend;
+T_11.331;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x246a250 .scope module, "yosys__31_" "fiftyfivenm_lcell_comb" 3 159, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x246a3e0 .param/str "dont_touch" 0 4 34, "off";
+P_0x246a420 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x246a460 .param/l "lut_mask" 0 4 32, C4<0101001101010011>;
+P_0x246a4a0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248d040 .functor BUFZ 1, L_0x248d5b0, C4<0>, C4<0>, C4<0>;
+L_0x248d0b0 .functor BUFZ 1, L_0x248ca10, C4<0>, C4<0>, C4<0>;
+L_0x248d150 .functor BUFZ 1, L_0x24939d0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad918 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248d1f0 .functor BUFZ 1, L_0x7f14f87ad918, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad888 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248d320 .functor AND 1, v0x246b310_0, L_0x7f14f87ad888, C4<1>, C4<1>;
+L_0x7f14f87ad8d0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248d450 .functor AND 1, v0x246b470_0, L_0x7f14f87ad8d0, C4<1>, C4<1>;
+v0x246aee0_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad8d0;  1 drivers
+v0x246afe0_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad888;  1 drivers
+o0x7f14f87fa188 .functor BUFZ 1, C4<z>; HiZ drive
+v0x246b0c0_0 .net "cin", 0 0, o0x7f14f87fa188;  0 drivers
+o0x7f14f87fa1b8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x246b160_0 .net "cin_w", 0 0, o0x7f14f87fa1b8;  0 drivers
+v0x246b220_0 .net "combout", 0 0, L_0x248d320;  alias, 1 drivers
+v0x246b310_0 .var "combout_rt", 0 0;
+v0x246b3b0_0 .net "cout", 0 0, L_0x248d450;  1 drivers
+v0x246b470_0 .var "cout_rt", 0 0;
+v0x246b530_0 .net "dataa", 0 0, L_0x248d5b0;  1 drivers
+v0x246b680_0 .net "dataa_w", 0 0, L_0x248d040;  1 drivers
+v0x246b740_0 .net "datab", 0 0, L_0x248ca10;  1 drivers
+v0x246b800_0 .net "datab_w", 0 0, L_0x248d0b0;  1 drivers
+v0x246b8c0_0 .net "datac", 0 0, L_0x24939d0;  alias, 1 drivers
+v0x246b960_0 .net "datac_w", 0 0, L_0x248d150;  1 drivers
+v0x246ba20_0 .net "datad", 0 0, L_0x7f14f87ad918;  1 drivers
+v0x246bae0_0 .net "datad_w", 0 0, L_0x248d1f0;  1 drivers
+v0x246bba0_0 .var "lut_type", 1 0;
+E_0x24689e0/0 .event edge, v0x246b160_0, v0x246bae0_0, v0x246b960_0, v0x246b800_0;
+E_0x24689e0/1 .event edge, v0x246b680_0;
+E_0x24689e0 .event/or E_0x24689e0/0, E_0x24689e0/1;
+S_0x246a7f0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x246a250;
+ .timescale 0 0;
+v0x246a9f0_0 .var "dataa", 0 0;
+v0x246aad0_0 .var "datab", 0 0;
+v0x246ab90_0 .var "datac", 0 0;
+v0x246ac30_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x246a7f0
+v0x246ae00_0 .var "mask", 15 0;
+TD_tb.U.yosys__31_.lut_data ;
+    %load/vec4 v0x246ac30_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_12.360, 8;
+    %load/vec4 v0x246ab90_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_12.362, 9;
+    %load/vec4 v0x246aad0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_12.364, 10;
+    %load/vec4 v0x246a9f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_12.366, 11;
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_12.367, 11;
+T_12.366 ; End of true expr.
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_12.367, 11;
+ ; End of false expr.
+    %blend;
+T_12.367;
+    %jmp/1 T_12.365, 10;
+T_12.364 ; End of true expr.
+    %load/vec4 v0x246a9f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_12.368, 11;
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_12.369, 11;
+T_12.368 ; End of true expr.
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_12.369, 11;
+ ; End of false expr.
+    %blend;
+T_12.369;
+    %jmp/0 T_12.365, 10;
+ ; End of false expr.
+    %blend;
+T_12.365;
+    %jmp/1 T_12.363, 9;
+T_12.362 ; End of true expr.
+    %load/vec4 v0x246aad0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_12.370, 10;
+    %load/vec4 v0x246a9f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_12.372, 11;
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_12.373, 11;
+T_12.372 ; End of true expr.
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_12.373, 11;
+ ; End of false expr.
+    %blend;
+T_12.373;
+    %jmp/1 T_12.371, 10;
+T_12.370 ; End of true expr.
+    %load/vec4 v0x246a9f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_12.374, 11;
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_12.375, 11;
+T_12.374 ; End of true expr.
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_12.375, 11;
+ ; End of false expr.
+    %blend;
+T_12.375;
+    %jmp/0 T_12.371, 10;
+ ; End of false expr.
+    %blend;
+T_12.371;
+    %jmp/0 T_12.363, 9;
+ ; End of false expr.
+    %blend;
+T_12.363;
+    %jmp/1 T_12.361, 8;
+T_12.360 ; End of true expr.
+    %load/vec4 v0x246ab90_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_12.376, 9;
+    %load/vec4 v0x246aad0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_12.378, 10;
+    %load/vec4 v0x246a9f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_12.380, 11;
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_12.381, 11;
+T_12.380 ; End of true expr.
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_12.381, 11;
+ ; End of false expr.
+    %blend;
+T_12.381;
+    %jmp/1 T_12.379, 10;
+T_12.378 ; End of true expr.
+    %load/vec4 v0x246a9f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_12.382, 11;
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_12.383, 11;
+T_12.382 ; End of true expr.
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_12.383, 11;
+ ; End of false expr.
+    %blend;
+T_12.383;
+    %jmp/0 T_12.379, 10;
+ ; End of false expr.
+    %blend;
+T_12.379;
+    %jmp/1 T_12.377, 9;
+T_12.376 ; End of true expr.
+    %load/vec4 v0x246aad0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_12.384, 10;
+    %load/vec4 v0x246a9f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_12.386, 11;
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_12.387, 11;
+T_12.386 ; End of true expr.
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_12.387, 11;
+ ; End of false expr.
+    %blend;
+T_12.387;
+    %jmp/1 T_12.385, 10;
+T_12.384 ; End of true expr.
+    %load/vec4 v0x246a9f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_12.388, 11;
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_12.389, 11;
+T_12.388 ; End of true expr.
+    %load/vec4 v0x246ae00_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_12.389, 11;
+ ; End of false expr.
+    %blend;
+T_12.389;
+    %jmp/0 T_12.385, 10;
+ ; End of false expr.
+    %blend;
+T_12.385;
+    %jmp/0 T_12.377, 9;
+ ; End of false expr.
+    %blend;
+T_12.377;
+    %jmp/0 T_12.361, 8;
+ ; End of false expr.
+    %blend;
+T_12.361;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x246be30 .scope module, "yosys__32_" "fiftyfivenm_lcell_comb" 3 169, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x246bfc0 .param/str "dont_touch" 0 4 34, "off";
+P_0x246c000 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x246c040 .param/l "lut_mask" 0 4 32, C4<1001011001101001>;
+P_0x246c080 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248a860 .functor BUFZ 1, L_0x248ddf0, C4<0>, C4<0>, C4<0>;
+L_0x248a8d0 .functor BUFZ 1, L_0x248d6a0, C4<0>, C4<0>, C4<0>;
+L_0x248da00 .functor BUFZ 1, L_0x248dff0, C4<0>, C4<0>, C4<0>;
+L_0x248da70 .functor BUFZ 1, L_0x248dee0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad960 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248dba0 .functor AND 1, v0x246cf40_0, L_0x7f14f87ad960, C4<1>, C4<1>;
+L_0x7f14f87ad9a8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248dc90 .functor AND 1, v0x246d0c0_0, L_0x7f14f87ad9a8, C4<1>, C4<1>;
+v0x246caf0_0 .net/2u *"_s12", 0 0, L_0x7f14f87ad9a8;  1 drivers
+v0x246cbf0_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad960;  1 drivers
+o0x7f14f87fa6c8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x246ccd0_0 .net "cin", 0 0, o0x7f14f87fa6c8;  0 drivers
+o0x7f14f87fa6f8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x246cd70_0 .net "cin_w", 0 0, o0x7f14f87fa6f8;  0 drivers
+v0x246ce30_0 .net "combout", 0 0, L_0x248dba0;  alias, 1 drivers
+v0x246cf40_0 .var "combout_rt", 0 0;
+v0x246d000_0 .net "cout", 0 0, L_0x248dc90;  1 drivers
+v0x246d0c0_0 .var "cout_rt", 0 0;
+v0x246d180_0 .net "dataa", 0 0, L_0x248ddf0;  1 drivers
+v0x246d2d0_0 .net "dataa_w", 0 0, L_0x248a860;  1 drivers
+v0x246d390_0 .net "datab", 0 0, L_0x248d6a0;  1 drivers
+v0x246d450_0 .net "datab_w", 0 0, L_0x248a8d0;  1 drivers
+v0x246d510_0 .net "datac", 0 0, L_0x248dff0;  1 drivers
+v0x246d5d0_0 .net "datac_w", 0 0, L_0x248da00;  1 drivers
+v0x246d690_0 .net "datad", 0 0, L_0x248dee0;  1 drivers
+v0x246d750_0 .net "datad_w", 0 0, L_0x248da70;  1 drivers
+v0x246d810_0 .var "lut_type", 1 0;
+E_0x246a5e0/0 .event edge, v0x246cd70_0, v0x246d750_0, v0x246d5d0_0, v0x246d450_0;
+E_0x246a5e0/1 .event edge, v0x246d2d0_0;
+E_0x246a5e0 .event/or E_0x246a5e0/0, E_0x246a5e0/1;
+S_0x246c400 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x246be30;
+ .timescale 0 0;
+v0x246c600_0 .var "dataa", 0 0;
+v0x246c6e0_0 .var "datab", 0 0;
+v0x246c7a0_0 .var "datac", 0 0;
+v0x246c840_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x246c400
+v0x246ca10_0 .var "mask", 15 0;
+TD_tb.U.yosys__32_.lut_data ;
+    %load/vec4 v0x246c840_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_13.390, 8;
+    %load/vec4 v0x246c7a0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_13.392, 9;
+    %load/vec4 v0x246c6e0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_13.394, 10;
+    %load/vec4 v0x246c600_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_13.396, 11;
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_13.397, 11;
+T_13.396 ; End of true expr.
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_13.397, 11;
+ ; End of false expr.
+    %blend;
+T_13.397;
+    %jmp/1 T_13.395, 10;
+T_13.394 ; End of true expr.
+    %load/vec4 v0x246c600_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_13.398, 11;
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_13.399, 11;
+T_13.398 ; End of true expr.
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_13.399, 11;
+ ; End of false expr.
+    %blend;
+T_13.399;
+    %jmp/0 T_13.395, 10;
+ ; End of false expr.
+    %blend;
+T_13.395;
+    %jmp/1 T_13.393, 9;
+T_13.392 ; End of true expr.
+    %load/vec4 v0x246c6e0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_13.400, 10;
+    %load/vec4 v0x246c600_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_13.402, 11;
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_13.403, 11;
+T_13.402 ; End of true expr.
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_13.403, 11;
+ ; End of false expr.
+    %blend;
+T_13.403;
+    %jmp/1 T_13.401, 10;
+T_13.400 ; End of true expr.
+    %load/vec4 v0x246c600_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_13.404, 11;
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_13.405, 11;
+T_13.404 ; End of true expr.
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_13.405, 11;
+ ; End of false expr.
+    %blend;
+T_13.405;
+    %jmp/0 T_13.401, 10;
+ ; End of false expr.
+    %blend;
+T_13.401;
+    %jmp/0 T_13.393, 9;
+ ; End of false expr.
+    %blend;
+T_13.393;
+    %jmp/1 T_13.391, 8;
+T_13.390 ; End of true expr.
+    %load/vec4 v0x246c7a0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_13.406, 9;
+    %load/vec4 v0x246c6e0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_13.408, 10;
+    %load/vec4 v0x246c600_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_13.410, 11;
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_13.411, 11;
+T_13.410 ; End of true expr.
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_13.411, 11;
+ ; End of false expr.
+    %blend;
+T_13.411;
+    %jmp/1 T_13.409, 10;
+T_13.408 ; End of true expr.
+    %load/vec4 v0x246c600_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_13.412, 11;
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_13.413, 11;
+T_13.412 ; End of true expr.
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_13.413, 11;
+ ; End of false expr.
+    %blend;
+T_13.413;
+    %jmp/0 T_13.409, 10;
+ ; End of false expr.
+    %blend;
+T_13.409;
+    %jmp/1 T_13.407, 9;
+T_13.406 ; End of true expr.
+    %load/vec4 v0x246c6e0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_13.414, 10;
+    %load/vec4 v0x246c600_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_13.416, 11;
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_13.417, 11;
+T_13.416 ; End of true expr.
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_13.417, 11;
+ ; End of false expr.
+    %blend;
+T_13.417;
+    %jmp/1 T_13.415, 10;
+T_13.414 ; End of true expr.
+    %load/vec4 v0x246c600_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_13.418, 11;
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_13.419, 11;
+T_13.418 ; End of true expr.
+    %load/vec4 v0x246ca10_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_13.419, 11;
+ ; End of false expr.
+    %blend;
+T_13.419;
+    %jmp/0 T_13.415, 10;
+ ; End of false expr.
+    %blend;
+T_13.415;
+    %jmp/0 T_13.407, 9;
+ ; End of false expr.
+    %blend;
+T_13.407;
+    %jmp/0 T_13.391, 8;
+ ; End of false expr.
+    %blend;
+T_13.391;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x246daa0 .scope module, "yosys__33_" "fiftyfivenm_lcell_comb" 3 179, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x246dc30 .param/str "dont_touch" 0 4 34, "off";
+P_0x246dc70 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x246dcb0 .param/l "lut_mask" 0 4 32, C4<0000000101000000>;
+P_0x246dcf0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248e200 .functor BUFZ 1, L_0x248e6a0, C4<0>, C4<0>, C4<0>;
+L_0x248e270 .functor BUFZ 1, L_0x248e0e0, C4<0>, C4<0>, C4<0>;
+L_0x248e2e0 .functor BUFZ 1, L_0x24939d0, C4<0>, C4<0>, C4<0>;
+L_0x248e350 .functor BUFZ 1, L_0x248e8c0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ad9f0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248e450 .functor AND 1, v0x246eb80_0, L_0x7f14f87ad9f0, C4<1>, C4<1>;
+L_0x7f14f87ada38 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248e540 .functor AND 1, v0x246ed00_0, L_0x7f14f87ada38, C4<1>, C4<1>;
+v0x246e730_0 .net/2u *"_s12", 0 0, L_0x7f14f87ada38;  1 drivers
+v0x246e830_0 .net/2u *"_s8", 0 0, L_0x7f14f87ad9f0;  1 drivers
+o0x7f14f87fac68 .functor BUFZ 1, C4<z>; HiZ drive
+v0x246e910_0 .net "cin", 0 0, o0x7f14f87fac68;  0 drivers
+o0x7f14f87fac98 .functor BUFZ 1, C4<z>; HiZ drive
+v0x246e9b0_0 .net "cin_w", 0 0, o0x7f14f87fac98;  0 drivers
+v0x246ea70_0 .net "combout", 0 0, L_0x248e450;  alias, 1 drivers
+v0x246eb80_0 .var "combout_rt", 0 0;
+v0x246ec40_0 .net "cout", 0 0, L_0x248e540;  1 drivers
+v0x246ed00_0 .var "cout_rt", 0 0;
+v0x246edc0_0 .net "dataa", 0 0, L_0x248e6a0;  1 drivers
+v0x246ef10_0 .net "dataa_w", 0 0, L_0x248e200;  1 drivers
+v0x246efd0_0 .net "datab", 0 0, L_0x248e0e0;  1 drivers
+v0x246f090_0 .net "datab_w", 0 0, L_0x248e270;  1 drivers
+v0x246f150_0 .net "datac", 0 0, L_0x24939d0;  alias, 1 drivers
+v0x246f1f0_0 .net "datac_w", 0 0, L_0x248e2e0;  1 drivers
+v0x246f2b0_0 .net "datad", 0 0, L_0x248e8c0;  1 drivers
+v0x246f370_0 .net "datad_w", 0 0, L_0x248e350;  1 drivers
+v0x246f430_0 .var "lut_type", 1 0;
+E_0x246c1f0/0 .event edge, v0x246e9b0_0, v0x246f370_0, v0x246f1f0_0, v0x246f090_0;
+E_0x246c1f0/1 .event edge, v0x246ef10_0;
+E_0x246c1f0 .event/or E_0x246c1f0/0, E_0x246c1f0/1;
+S_0x246e040 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x246daa0;
+ .timescale 0 0;
+v0x246e240_0 .var "dataa", 0 0;
+v0x246e320_0 .var "datab", 0 0;
+v0x246e3e0_0 .var "datac", 0 0;
+v0x246e480_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x246e040
+v0x246e650_0 .var "mask", 15 0;
+TD_tb.U.yosys__33_.lut_data ;
+    %load/vec4 v0x246e480_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_14.420, 8;
+    %load/vec4 v0x246e3e0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_14.422, 9;
+    %load/vec4 v0x246e320_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_14.424, 10;
+    %load/vec4 v0x246e240_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_14.426, 11;
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_14.427, 11;
+T_14.426 ; End of true expr.
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_14.427, 11;
+ ; End of false expr.
+    %blend;
+T_14.427;
+    %jmp/1 T_14.425, 10;
+T_14.424 ; End of true expr.
+    %load/vec4 v0x246e240_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_14.428, 11;
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_14.429, 11;
+T_14.428 ; End of true expr.
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_14.429, 11;
+ ; End of false expr.
+    %blend;
+T_14.429;
+    %jmp/0 T_14.425, 10;
+ ; End of false expr.
+    %blend;
+T_14.425;
+    %jmp/1 T_14.423, 9;
+T_14.422 ; End of true expr.
+    %load/vec4 v0x246e320_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_14.430, 10;
+    %load/vec4 v0x246e240_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_14.432, 11;
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_14.433, 11;
+T_14.432 ; End of true expr.
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_14.433, 11;
+ ; End of false expr.
+    %blend;
+T_14.433;
+    %jmp/1 T_14.431, 10;
+T_14.430 ; End of true expr.
+    %load/vec4 v0x246e240_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_14.434, 11;
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_14.435, 11;
+T_14.434 ; End of true expr.
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_14.435, 11;
+ ; End of false expr.
+    %blend;
+T_14.435;
+    %jmp/0 T_14.431, 10;
+ ; End of false expr.
+    %blend;
+T_14.431;
+    %jmp/0 T_14.423, 9;
+ ; End of false expr.
+    %blend;
+T_14.423;
+    %jmp/1 T_14.421, 8;
+T_14.420 ; End of true expr.
+    %load/vec4 v0x246e3e0_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_14.436, 9;
+    %load/vec4 v0x246e320_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_14.438, 10;
+    %load/vec4 v0x246e240_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_14.440, 11;
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_14.441, 11;
+T_14.440 ; End of true expr.
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_14.441, 11;
+ ; End of false expr.
+    %blend;
+T_14.441;
+    %jmp/1 T_14.439, 10;
+T_14.438 ; End of true expr.
+    %load/vec4 v0x246e240_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_14.442, 11;
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_14.443, 11;
+T_14.442 ; End of true expr.
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_14.443, 11;
+ ; End of false expr.
+    %blend;
+T_14.443;
+    %jmp/0 T_14.439, 10;
+ ; End of false expr.
+    %blend;
+T_14.439;
+    %jmp/1 T_14.437, 9;
+T_14.436 ; End of true expr.
+    %load/vec4 v0x246e320_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_14.444, 10;
+    %load/vec4 v0x246e240_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_14.446, 11;
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_14.447, 11;
+T_14.446 ; End of true expr.
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_14.447, 11;
+ ; End of false expr.
+    %blend;
+T_14.447;
+    %jmp/1 T_14.445, 10;
+T_14.444 ; End of true expr.
+    %load/vec4 v0x246e240_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_14.448, 11;
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_14.449, 11;
+T_14.448 ; End of true expr.
+    %load/vec4 v0x246e650_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_14.449, 11;
+ ; End of false expr.
+    %blend;
+T_14.449;
+    %jmp/0 T_14.445, 10;
+ ; End of false expr.
+    %blend;
+T_14.445;
+    %jmp/0 T_14.437, 9;
+ ; End of false expr.
+    %blend;
+T_14.437;
+    %jmp/0 T_14.421, 8;
+ ; End of false expr.
+    %blend;
+T_14.421;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x246f6c0 .scope module, "yosys__34_" "fiftyfivenm_lcell_comb" 3 189, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x246f850 .param/str "dont_touch" 0 4 34, "off";
+P_0x246f890 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x246f8d0 .param/l "lut_mask" 0 4 32, C4<0001000000000000>;
+P_0x246f910 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248e790 .functor BUFZ 1, L_0x248eeb0, C4<0>, C4<0>, C4<0>;
+L_0x248e800 .functor BUFZ 1, L_0x248efa0, C4<0>, C4<0>, C4<0>;
+L_0x248eaa0 .functor BUFZ 1, L_0x248e450, C4<0>, C4<0>, C4<0>;
+L_0x248eba0 .functor BUFZ 1, L_0x2487ea0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ada80 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248ed00 .functor AND 1, v0x24707a0_0, L_0x7f14f87ada80, C4<1>, C4<1>;
+L_0x7f14f87adac8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248eda0 .functor AND 1, v0x2470920_0, L_0x7f14f87adac8, C4<1>, C4<1>;
+v0x2470350_0 .net/2u *"_s12", 0 0, L_0x7f14f87adac8;  1 drivers
+v0x2470450_0 .net/2u *"_s8", 0 0, L_0x7f14f87ada80;  1 drivers
+o0x7f14f87fb1d8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2470530_0 .net "cin", 0 0, o0x7f14f87fb1d8;  0 drivers
+o0x7f14f87fb208 .functor BUFZ 1, C4<z>; HiZ drive
+v0x24705d0_0 .net "cin_w", 0 0, o0x7f14f87fb208;  0 drivers
+v0x2470690_0 .net "combout", 0 0, L_0x248ed00;  alias, 1 drivers
+v0x24707a0_0 .var "combout_rt", 0 0;
+v0x2470860_0 .net "cout", 0 0, L_0x248eda0;  1 drivers
+v0x2470920_0 .var "cout_rt", 0 0;
+v0x24709e0_0 .net "dataa", 0 0, L_0x248eeb0;  1 drivers
+v0x2470b30_0 .net "dataa_w", 0 0, L_0x248e790;  1 drivers
+v0x2470bf0_0 .net "datab", 0 0, L_0x248efa0;  1 drivers
+v0x2470cb0_0 .net "datab_w", 0 0, L_0x248e800;  1 drivers
+v0x2470d70_0 .net "datac", 0 0, L_0x248e450;  alias, 1 drivers
+v0x2470e10_0 .net "datac_w", 0 0, L_0x248eaa0;  1 drivers
+v0x2470eb0_0 .net "datad", 0 0, L_0x2487ea0;  alias, 1 drivers
+v0x2470f80_0 .net "datad_w", 0 0, L_0x248eba0;  1 drivers
+v0x2471040_0 .var "lut_type", 1 0;
+E_0x246de30/0 .event edge, v0x24705d0_0, v0x2470f80_0, v0x2470e10_0, v0x2470cb0_0;
+E_0x246de30/1 .event edge, v0x2470b30_0;
+E_0x246de30 .event/or E_0x246de30/0, E_0x246de30/1;
+S_0x246fc60 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x246f6c0;
+ .timescale 0 0;
+v0x246fe60_0 .var "dataa", 0 0;
+v0x246ff40_0 .var "datab", 0 0;
+v0x2470000_0 .var "datac", 0 0;
+v0x24700a0_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x246fc60
+v0x2470270_0 .var "mask", 15 0;
+TD_tb.U.yosys__34_.lut_data ;
+    %load/vec4 v0x24700a0_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_15.450, 8;
+    %load/vec4 v0x2470000_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_15.452, 9;
+    %load/vec4 v0x246ff40_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_15.454, 10;
+    %load/vec4 v0x246fe60_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_15.456, 11;
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_15.457, 11;
+T_15.456 ; End of true expr.
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_15.457, 11;
+ ; End of false expr.
+    %blend;
+T_15.457;
+    %jmp/1 T_15.455, 10;
+T_15.454 ; End of true expr.
+    %load/vec4 v0x246fe60_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_15.458, 11;
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_15.459, 11;
+T_15.458 ; End of true expr.
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_15.459, 11;
+ ; End of false expr.
+    %blend;
+T_15.459;
+    %jmp/0 T_15.455, 10;
+ ; End of false expr.
+    %blend;
+T_15.455;
+    %jmp/1 T_15.453, 9;
+T_15.452 ; End of true expr.
+    %load/vec4 v0x246ff40_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_15.460, 10;
+    %load/vec4 v0x246fe60_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_15.462, 11;
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_15.463, 11;
+T_15.462 ; End of true expr.
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_15.463, 11;
+ ; End of false expr.
+    %blend;
+T_15.463;
+    %jmp/1 T_15.461, 10;
+T_15.460 ; End of true expr.
+    %load/vec4 v0x246fe60_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_15.464, 11;
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_15.465, 11;
+T_15.464 ; End of true expr.
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_15.465, 11;
+ ; End of false expr.
+    %blend;
+T_15.465;
+    %jmp/0 T_15.461, 10;
+ ; End of false expr.
+    %blend;
+T_15.461;
+    %jmp/0 T_15.453, 9;
+ ; End of false expr.
+    %blend;
+T_15.453;
+    %jmp/1 T_15.451, 8;
+T_15.450 ; End of true expr.
+    %load/vec4 v0x2470000_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_15.466, 9;
+    %load/vec4 v0x246ff40_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_15.468, 10;
+    %load/vec4 v0x246fe60_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_15.470, 11;
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_15.471, 11;
+T_15.470 ; End of true expr.
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_15.471, 11;
+ ; End of false expr.
+    %blend;
+T_15.471;
+    %jmp/1 T_15.469, 10;
+T_15.468 ; End of true expr.
+    %load/vec4 v0x246fe60_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_15.472, 11;
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_15.473, 11;
+T_15.472 ; End of true expr.
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_15.473, 11;
+ ; End of false expr.
+    %blend;
+T_15.473;
+    %jmp/0 T_15.469, 10;
+ ; End of false expr.
+    %blend;
+T_15.469;
+    %jmp/1 T_15.467, 9;
+T_15.466 ; End of true expr.
+    %load/vec4 v0x246ff40_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_15.474, 10;
+    %load/vec4 v0x246fe60_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_15.476, 11;
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_15.477, 11;
+T_15.476 ; End of true expr.
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_15.477, 11;
+ ; End of false expr.
+    %blend;
+T_15.477;
+    %jmp/1 T_15.475, 10;
+T_15.474 ; End of true expr.
+    %load/vec4 v0x246fe60_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_15.478, 11;
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_15.479, 11;
+T_15.478 ; End of true expr.
+    %load/vec4 v0x2470270_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_15.479, 11;
+ ; End of false expr.
+    %blend;
+T_15.479;
+    %jmp/0 T_15.475, 10;
+ ; End of false expr.
+    %blend;
+T_15.475;
+    %jmp/0 T_15.467, 9;
+ ; End of false expr.
+    %blend;
+T_15.467;
+    %jmp/0 T_15.451, 8;
+ ; End of false expr.
+    %blend;
+T_15.451;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x24712d0 .scope module, "yosys__35_" "fiftyfivenm_lcell_comb" 3 199, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2471570 .param/str "dont_touch" 0 4 34, "off";
+P_0x24715b0 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x24715f0 .param/l "lut_mask" 0 4 32, C4<0111000001110000>;
+P_0x2471630 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248e9b0 .functor BUFZ 1, L_0x2493340, C4<0>, C4<0>, C4<0>;
+L_0x248ea20 .functor BUFZ 1, L_0x24939d0, C4<0>, C4<0>, C4<0>;
+L_0x248f190 .functor BUFZ 1, L_0x248f580, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87adba0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248f200 .functor BUFZ 1, L_0x7f14f87adba0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87adb10 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248f330 .functor AND 1, v0x2472430_0, L_0x7f14f87adb10, C4<1>, C4<1>;
+L_0x7f14f87adb58 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248f420 .functor AND 1, v0x24725b0_0, L_0x7f14f87adb58, C4<1>, C4<1>;
+v0x2471fe0_0 .net/2u *"_s12", 0 0, L_0x7f14f87adb58;  1 drivers
+v0x24720e0_0 .net/2u *"_s8", 0 0, L_0x7f14f87adb10;  1 drivers
+o0x7f14f87fb718 .functor BUFZ 1, C4<z>; HiZ drive
+v0x24721c0_0 .net "cin", 0 0, o0x7f14f87fb718;  0 drivers
+o0x7f14f87fb748 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2472260_0 .net "cin_w", 0 0, o0x7f14f87fb748;  0 drivers
+v0x2472320_0 .net "combout", 0 0, L_0x248f330;  alias, 1 drivers
+v0x2472430_0 .var "combout_rt", 0 0;
+v0x24724f0_0 .net "cout", 0 0, L_0x248f420;  1 drivers
+v0x24725b0_0 .var "cout_rt", 0 0;
+v0x2472670_0 .net "dataa", 0 0, L_0x2493340;  alias, 1 drivers
+v0x24727a0_0 .net "dataa_w", 0 0, L_0x248e9b0;  1 drivers
+v0x2472860_0 .net "datab", 0 0, L_0x24939d0;  alias, 1 drivers
+v0x2472900_0 .net "datab_w", 0 0, L_0x248ea20;  1 drivers
+v0x24729c0_0 .net "datac", 0 0, L_0x248f580;  1 drivers
+v0x2472a80_0 .net "datac_w", 0 0, L_0x248f190;  1 drivers
+v0x2472b40_0 .net "datad", 0 0, L_0x7f14f87adba0;  1 drivers
+v0x2472c00_0 .net "datad_w", 0 0, L_0x248f200;  1 drivers
+v0x2472cc0_0 .var "lut_type", 1 0;
+E_0x2463310/0 .event edge, v0x2472260_0, v0x2472c00_0, v0x2472a80_0, v0x2472900_0;
+E_0x2463310/1 .event edge, v0x24727a0_0;
+E_0x2463310 .event/or E_0x2463310/0, E_0x2463310/1;
+S_0x24718f0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x24712d0;
+ .timescale 0 0;
+v0x2471af0_0 .var "dataa", 0 0;
+v0x2471bd0_0 .var "datab", 0 0;
+v0x2471c90_0 .var "datac", 0 0;
+v0x2471d30_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x24718f0
+v0x2471f00_0 .var "mask", 15 0;
+TD_tb.U.yosys__35_.lut_data ;
+    %load/vec4 v0x2471d30_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_16.480, 8;
+    %load/vec4 v0x2471c90_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_16.482, 9;
+    %load/vec4 v0x2471bd0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_16.484, 10;
+    %load/vec4 v0x2471af0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_16.486, 11;
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_16.487, 11;
+T_16.486 ; End of true expr.
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_16.487, 11;
+ ; End of false expr.
+    %blend;
+T_16.487;
+    %jmp/1 T_16.485, 10;
+T_16.484 ; End of true expr.
+    %load/vec4 v0x2471af0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_16.488, 11;
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_16.489, 11;
+T_16.488 ; End of true expr.
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_16.489, 11;
+ ; End of false expr.
+    %blend;
+T_16.489;
+    %jmp/0 T_16.485, 10;
+ ; End of false expr.
+    %blend;
+T_16.485;
+    %jmp/1 T_16.483, 9;
+T_16.482 ; End of true expr.
+    %load/vec4 v0x2471bd0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_16.490, 10;
+    %load/vec4 v0x2471af0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_16.492, 11;
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_16.493, 11;
+T_16.492 ; End of true expr.
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_16.493, 11;
+ ; End of false expr.
+    %blend;
+T_16.493;
+    %jmp/1 T_16.491, 10;
+T_16.490 ; End of true expr.
+    %load/vec4 v0x2471af0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_16.494, 11;
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_16.495, 11;
+T_16.494 ; End of true expr.
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_16.495, 11;
+ ; End of false expr.
+    %blend;
+T_16.495;
+    %jmp/0 T_16.491, 10;
+ ; End of false expr.
+    %blend;
+T_16.491;
+    %jmp/0 T_16.483, 9;
+ ; End of false expr.
+    %blend;
+T_16.483;
+    %jmp/1 T_16.481, 8;
+T_16.480 ; End of true expr.
+    %load/vec4 v0x2471c90_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_16.496, 9;
+    %load/vec4 v0x2471bd0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_16.498, 10;
+    %load/vec4 v0x2471af0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_16.500, 11;
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_16.501, 11;
+T_16.500 ; End of true expr.
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_16.501, 11;
+ ; End of false expr.
+    %blend;
+T_16.501;
+    %jmp/1 T_16.499, 10;
+T_16.498 ; End of true expr.
+    %load/vec4 v0x2471af0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_16.502, 11;
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_16.503, 11;
+T_16.502 ; End of true expr.
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_16.503, 11;
+ ; End of false expr.
+    %blend;
+T_16.503;
+    %jmp/0 T_16.499, 10;
+ ; End of false expr.
+    %blend;
+T_16.499;
+    %jmp/1 T_16.497, 9;
+T_16.496 ; End of true expr.
+    %load/vec4 v0x2471bd0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_16.504, 10;
+    %load/vec4 v0x2471af0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_16.506, 11;
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_16.507, 11;
+T_16.506 ; End of true expr.
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_16.507, 11;
+ ; End of false expr.
+    %blend;
+T_16.507;
+    %jmp/1 T_16.505, 10;
+T_16.504 ; End of true expr.
+    %load/vec4 v0x2471af0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_16.508, 11;
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_16.509, 11;
+T_16.508 ; End of true expr.
+    %load/vec4 v0x2471f00_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_16.509, 11;
+ ; End of false expr.
+    %blend;
+T_16.509;
+    %jmp/0 T_16.505, 10;
+ ; End of false expr.
+    %blend;
+T_16.505;
+    %jmp/0 T_16.497, 9;
+ ; End of false expr.
+    %blend;
+T_16.497;
+    %jmp/0 T_16.481, 8;
+ ; End of false expr.
+    %blend;
+T_16.481;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x2472f50 .scope module, "yosys__36_" "fiftyfivenm_lcell_comb" 3 209, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x24730e0 .param/str "dont_touch" 0 4 34, "off";
+P_0x2473120 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x2473160 .param/l "lut_mask" 0 4 32, C4<1010101011000011>;
+P_0x24731a0 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248f6c0 .functor BUFZ 1, L_0x248fbc0, C4<0>, C4<0>, C4<0>;
+L_0x248f730 .functor BUFZ 1, L_0x248c160, C4<0>, C4<0>, C4<0>;
+L_0x248f7a0 .functor BUFZ 1, L_0x248f090, C4<0>, C4<0>, C4<0>;
+L_0x248f870 .functor BUFZ 1, L_0x24939d0, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87adbe8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248f970 .functor AND 1, v0x2474030_0, L_0x7f14f87adbe8, C4<1>, C4<1>;
+L_0x7f14f87adc30 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x248fa60 .functor AND 1, v0x24741b0_0, L_0x7f14f87adc30, C4<1>, C4<1>;
+v0x2473be0_0 .net/2u *"_s12", 0 0, L_0x7f14f87adc30;  1 drivers
+v0x2473ce0_0 .net/2u *"_s8", 0 0, L_0x7f14f87adbe8;  1 drivers
+o0x7f14f87fbc58 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2473dc0_0 .net "cin", 0 0, o0x7f14f87fbc58;  0 drivers
+o0x7f14f87fbc88 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2473e60_0 .net "cin_w", 0 0, o0x7f14f87fbc88;  0 drivers
+v0x2473f20_0 .net "combout", 0 0, L_0x248f970;  alias, 1 drivers
+v0x2474030_0 .var "combout_rt", 0 0;
+v0x24740f0_0 .net "cout", 0 0, L_0x248fa60;  1 drivers
+v0x24741b0_0 .var "cout_rt", 0 0;
+v0x2474270_0 .net "dataa", 0 0, L_0x248fbc0;  1 drivers
+v0x24743c0_0 .net "dataa_w", 0 0, L_0x248f6c0;  1 drivers
+v0x2474480_0 .net "datab", 0 0, L_0x248c160;  1 drivers
+v0x2474540_0 .net "datab_w", 0 0, L_0x248f730;  1 drivers
+v0x2474600_0 .net "datac", 0 0, L_0x248f090;  1 drivers
+v0x24746c0_0 .net "datac_w", 0 0, L_0x248f7a0;  1 drivers
+v0x2474780_0 .net "datad", 0 0, L_0x24939d0;  alias, 1 drivers
+v0x2474930_0 .net "datad_w", 0 0, L_0x248f870;  1 drivers
+v0x24749d0_0 .var "lut_type", 1 0;
+E_0x246fa50/0 .event edge, v0x2473e60_0, v0x2474930_0, v0x24746c0_0, v0x2474540_0;
+E_0x246fa50/1 .event edge, v0x24743c0_0;
+E_0x246fa50 .event/or E_0x246fa50/0, E_0x246fa50/1;
+S_0x24734f0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x2472f50;
+ .timescale 0 0;
+v0x24736f0_0 .var "dataa", 0 0;
+v0x24737d0_0 .var "datab", 0 0;
+v0x2473890_0 .var "datac", 0 0;
+v0x2473930_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x24734f0
+v0x2473b00_0 .var "mask", 15 0;
+TD_tb.U.yosys__36_.lut_data ;
+    %load/vec4 v0x2473930_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_17.510, 8;
+    %load/vec4 v0x2473890_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_17.512, 9;
+    %load/vec4 v0x24737d0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_17.514, 10;
+    %load/vec4 v0x24736f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_17.516, 11;
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_17.517, 11;
+T_17.516 ; End of true expr.
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_17.517, 11;
+ ; End of false expr.
+    %blend;
+T_17.517;
+    %jmp/1 T_17.515, 10;
+T_17.514 ; End of true expr.
+    %load/vec4 v0x24736f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_17.518, 11;
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_17.519, 11;
+T_17.518 ; End of true expr.
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_17.519, 11;
+ ; End of false expr.
+    %blend;
+T_17.519;
+    %jmp/0 T_17.515, 10;
+ ; End of false expr.
+    %blend;
+T_17.515;
+    %jmp/1 T_17.513, 9;
+T_17.512 ; End of true expr.
+    %load/vec4 v0x24737d0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_17.520, 10;
+    %load/vec4 v0x24736f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_17.522, 11;
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_17.523, 11;
+T_17.522 ; End of true expr.
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_17.523, 11;
+ ; End of false expr.
+    %blend;
+T_17.523;
+    %jmp/1 T_17.521, 10;
+T_17.520 ; End of true expr.
+    %load/vec4 v0x24736f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_17.524, 11;
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_17.525, 11;
+T_17.524 ; End of true expr.
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_17.525, 11;
+ ; End of false expr.
+    %blend;
+T_17.525;
+    %jmp/0 T_17.521, 10;
+ ; End of false expr.
+    %blend;
+T_17.521;
+    %jmp/0 T_17.513, 9;
+ ; End of false expr.
+    %blend;
+T_17.513;
+    %jmp/1 T_17.511, 8;
+T_17.510 ; End of true expr.
+    %load/vec4 v0x2473890_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_17.526, 9;
+    %load/vec4 v0x24737d0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_17.528, 10;
+    %load/vec4 v0x24736f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_17.530, 11;
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_17.531, 11;
+T_17.530 ; End of true expr.
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_17.531, 11;
+ ; End of false expr.
+    %blend;
+T_17.531;
+    %jmp/1 T_17.529, 10;
+T_17.528 ; End of true expr.
+    %load/vec4 v0x24736f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_17.532, 11;
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_17.533, 11;
+T_17.532 ; End of true expr.
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_17.533, 11;
+ ; End of false expr.
+    %blend;
+T_17.533;
+    %jmp/0 T_17.529, 10;
+ ; End of false expr.
+    %blend;
+T_17.529;
+    %jmp/1 T_17.527, 9;
+T_17.526 ; End of true expr.
+    %load/vec4 v0x24737d0_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_17.534, 10;
+    %load/vec4 v0x24736f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_17.536, 11;
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_17.537, 11;
+T_17.536 ; End of true expr.
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_17.537, 11;
+ ; End of false expr.
+    %blend;
+T_17.537;
+    %jmp/1 T_17.535, 10;
+T_17.534 ; End of true expr.
+    %load/vec4 v0x24736f0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_17.538, 11;
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_17.539, 11;
+T_17.538 ; End of true expr.
+    %load/vec4 v0x2473b00_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_17.539, 11;
+ ; End of false expr.
+    %blend;
+T_17.539;
+    %jmp/0 T_17.535, 10;
+ ; End of false expr.
+    %blend;
+T_17.535;
+    %jmp/0 T_17.527, 9;
+ ; End of false expr.
+    %blend;
+T_17.527;
+    %jmp/0 T_17.511, 8;
+ ; End of false expr.
+    %blend;
+T_17.511;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x2474c00 .scope module, "yosys__37_" "fiftyfivenm_lcell_comb" 3 219, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2474d90 .param/str "dont_touch" 0 4 34, "off";
+P_0x2474dd0 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x2474e10 .param/l "lut_mask" 0 4 32, C4<0000011100001000>;
+P_0x2474e50 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x248b860 .functor BUFZ 1, L_0x248f970, C4<0>, C4<0>, C4<0>;
+L_0x248c0e0 .functor BUFZ 1, L_0x2493340, C4<0>, C4<0>, C4<0>;
+L_0x24901e0 .functor BUFZ 1, L_0x2493770, C4<0>, C4<0>, C4<0>;
+L_0x247dd70 .functor BUFZ 1, L_0x248f330, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87adc78 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x247de10 .functor AND 1, v0x2475ce0_0, L_0x7f14f87adc78, C4<1>, C4<1>;
+L_0x7f14f87adcc0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x24904f0 .functor AND 1, v0x2475e60_0, L_0x7f14f87adcc0, C4<1>, C4<1>;
+v0x2475890_0 .net/2u *"_s12", 0 0, L_0x7f14f87adcc0;  1 drivers
+v0x2475990_0 .net/2u *"_s8", 0 0, L_0x7f14f87adc78;  1 drivers
+o0x7f14f87fc1c8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2475a70_0 .net "cin", 0 0, o0x7f14f87fc1c8;  0 drivers
+o0x7f14f87fc1f8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2475b10_0 .net "cin_w", 0 0, o0x7f14f87fc1f8;  0 drivers
+v0x2475bd0_0 .net "combout", 0 0, L_0x247de10;  1 drivers
+v0x2475ce0_0 .var "combout_rt", 0 0;
+v0x2475da0_0 .net "cout", 0 0, L_0x24904f0;  1 drivers
+v0x2475e60_0 .var "cout_rt", 0 0;
+v0x2475f20_0 .net "dataa", 0 0, L_0x248f970;  alias, 1 drivers
+v0x2476050_0 .net "dataa_w", 0 0, L_0x248b860;  1 drivers
+v0x24760f0_0 .net "datab", 0 0, L_0x2493340;  alias, 1 drivers
+v0x2476190_0 .net "datab_w", 0 0, L_0x248c0e0;  1 drivers
+v0x2476250_0 .net "datac", 0 0, L_0x2493770;  alias, 1 drivers
+v0x24762f0_0 .net "datac_w", 0 0, L_0x24901e0;  1 drivers
+v0x24763b0_0 .net "datad", 0 0, L_0x248f330;  alias, 1 drivers
+v0x2476480_0 .net "datad_w", 0 0, L_0x247dd70;  1 drivers
+v0x2476520_0 .var "lut_type", 1 0;
+E_0x24732e0/0 .event edge, v0x2475b10_0, v0x2476480_0, v0x24762f0_0, v0x2476190_0;
+E_0x24732e0/1 .event edge, v0x2476050_0;
+E_0x24732e0 .event/or E_0x24732e0/0, E_0x24732e0/1;
+S_0x24751a0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x2474c00;
+ .timescale 0 0;
+v0x24753a0_0 .var "dataa", 0 0;
+v0x2475480_0 .var "datab", 0 0;
+v0x2475540_0 .var "datac", 0 0;
+v0x24755e0_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x24751a0
+v0x24757b0_0 .var "mask", 15 0;
+TD_tb.U.yosys__37_.lut_data ;
+    %load/vec4 v0x24755e0_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_18.540, 8;
+    %load/vec4 v0x2475540_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_18.542, 9;
+    %load/vec4 v0x2475480_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_18.544, 10;
+    %load/vec4 v0x24753a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_18.546, 11;
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_18.547, 11;
+T_18.546 ; End of true expr.
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_18.547, 11;
+ ; End of false expr.
+    %blend;
+T_18.547;
+    %jmp/1 T_18.545, 10;
+T_18.544 ; End of true expr.
+    %load/vec4 v0x24753a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_18.548, 11;
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_18.549, 11;
+T_18.548 ; End of true expr.
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_18.549, 11;
+ ; End of false expr.
+    %blend;
+T_18.549;
+    %jmp/0 T_18.545, 10;
+ ; End of false expr.
+    %blend;
+T_18.545;
+    %jmp/1 T_18.543, 9;
+T_18.542 ; End of true expr.
+    %load/vec4 v0x2475480_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_18.550, 10;
+    %load/vec4 v0x24753a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_18.552, 11;
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_18.553, 11;
+T_18.552 ; End of true expr.
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_18.553, 11;
+ ; End of false expr.
+    %blend;
+T_18.553;
+    %jmp/1 T_18.551, 10;
+T_18.550 ; End of true expr.
+    %load/vec4 v0x24753a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_18.554, 11;
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_18.555, 11;
+T_18.554 ; End of true expr.
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_18.555, 11;
+ ; End of false expr.
+    %blend;
+T_18.555;
+    %jmp/0 T_18.551, 10;
+ ; End of false expr.
+    %blend;
+T_18.551;
+    %jmp/0 T_18.543, 9;
+ ; End of false expr.
+    %blend;
+T_18.543;
+    %jmp/1 T_18.541, 8;
+T_18.540 ; End of true expr.
+    %load/vec4 v0x2475540_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_18.556, 9;
+    %load/vec4 v0x2475480_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_18.558, 10;
+    %load/vec4 v0x24753a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_18.560, 11;
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_18.561, 11;
+T_18.560 ; End of true expr.
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_18.561, 11;
+ ; End of false expr.
+    %blend;
+T_18.561;
+    %jmp/1 T_18.559, 10;
+T_18.558 ; End of true expr.
+    %load/vec4 v0x24753a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_18.562, 11;
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_18.563, 11;
+T_18.562 ; End of true expr.
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_18.563, 11;
+ ; End of false expr.
+    %blend;
+T_18.563;
+    %jmp/0 T_18.559, 10;
+ ; End of false expr.
+    %blend;
+T_18.559;
+    %jmp/1 T_18.557, 9;
+T_18.556 ; End of true expr.
+    %load/vec4 v0x2475480_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_18.564, 10;
+    %load/vec4 v0x24753a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_18.566, 11;
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_18.567, 11;
+T_18.566 ; End of true expr.
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_18.567, 11;
+ ; End of false expr.
+    %blend;
+T_18.567;
+    %jmp/1 T_18.565, 10;
+T_18.564 ; End of true expr.
+    %load/vec4 v0x24753a0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_18.568, 11;
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_18.569, 11;
+T_18.568 ; End of true expr.
+    %load/vec4 v0x24757b0_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_18.569, 11;
+ ; End of false expr.
+    %blend;
+T_18.569;
+    %jmp/0 T_18.565, 10;
+ ; End of false expr.
+    %blend;
+T_18.565;
+    %jmp/0 T_18.557, 9;
+ ; End of false expr.
+    %blend;
+T_18.557;
+    %jmp/0 T_18.541, 8;
+ ; End of false expr.
+    %blend;
+T_18.541;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x24767b0 .scope module, "yosys__38_" "fiftyfivenm_lcell_comb" 3 229, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2476940 .param/str "dont_touch" 0 4 34, "off";
+P_0x2476980 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x24769c0 .param/l "lut_mask" 0 4 32, C4<0000101000001100>;
+P_0x2476a00 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x2490590 .functor BUFZ 1, L_0x24939d0, C4<0>, C4<0>, C4<0>;
+L_0x2490600 .functor BUFZ 1, L_0x2490a90, C4<0>, C4<0>, C4<0>;
+L_0x24906d0 .functor BUFZ 1, L_0x2493770, C4<0>, C4<0>, C4<0>;
+L_0x2490770 .functor BUFZ 1, L_0x2493340, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87add08 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2490840 .functor AND 1, v0x24778c0_0, L_0x7f14f87add08, C4<1>, C4<1>;
+L_0x7f14f87add50 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2490930 .functor AND 1, v0x2477a40_0, L_0x7f14f87add50, C4<1>, C4<1>;
+v0x2477470_0 .net/2u *"_s12", 0 0, L_0x7f14f87add50;  1 drivers
+v0x2477570_0 .net/2u *"_s8", 0 0, L_0x7f14f87add08;  1 drivers
+o0x7f14f87fc6a8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2477650_0 .net "cin", 0 0, o0x7f14f87fc6a8;  0 drivers
+o0x7f14f87fc6d8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x24776f0_0 .net "cin_w", 0 0, o0x7f14f87fc6d8;  0 drivers
+v0x24777b0_0 .net "combout", 0 0, L_0x2490840;  alias, 1 drivers
+v0x24778c0_0 .var "combout_rt", 0 0;
+v0x2477980_0 .net "cout", 0 0, L_0x2490930;  1 drivers
+v0x2477a40_0 .var "cout_rt", 0 0;
+v0x2477b00_0 .net "dataa", 0 0, L_0x24939d0;  alias, 1 drivers
+v0x2477c30_0 .net "dataa_w", 0 0, L_0x2490590;  1 drivers
+v0x2477cf0_0 .net "datab", 0 0, L_0x2490a90;  1 drivers
+v0x2477db0_0 .net "datab_w", 0 0, L_0x2490600;  1 drivers
+v0x2477e70_0 .net "datac", 0 0, L_0x2493770;  alias, 1 drivers
+v0x2477f10_0 .net "datac_w", 0 0, L_0x24906d0;  1 drivers
+v0x2477fd0_0 .net "datad", 0 0, L_0x2493340;  alias, 1 drivers
+v0x2478180_0 .net "datad_w", 0 0, L_0x2490770;  1 drivers
+v0x2478220_0 .var "lut_type", 1 0;
+E_0x2474f90/0 .event edge, v0x24776f0_0, v0x2478180_0, v0x2477f10_0, v0x2477db0_0;
+E_0x2474f90/1 .event edge, v0x2477c30_0;
+E_0x2474f90 .event/or E_0x2474f90/0, E_0x2474f90/1;
+S_0x2476d80 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x24767b0;
+ .timescale 0 0;
+v0x2476f80_0 .var "dataa", 0 0;
+v0x2477060_0 .var "datab", 0 0;
+v0x2477120_0 .var "datac", 0 0;
+v0x24771c0_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x2476d80
+v0x2477390_0 .var "mask", 15 0;
+TD_tb.U.yosys__38_.lut_data ;
+    %load/vec4 v0x24771c0_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_19.570, 8;
+    %load/vec4 v0x2477120_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_19.572, 9;
+    %load/vec4 v0x2477060_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_19.574, 10;
+    %load/vec4 v0x2476f80_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_19.576, 11;
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_19.577, 11;
+T_19.576 ; End of true expr.
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_19.577, 11;
+ ; End of false expr.
+    %blend;
+T_19.577;
+    %jmp/1 T_19.575, 10;
+T_19.574 ; End of true expr.
+    %load/vec4 v0x2476f80_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_19.578, 11;
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_19.579, 11;
+T_19.578 ; End of true expr.
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_19.579, 11;
+ ; End of false expr.
+    %blend;
+T_19.579;
+    %jmp/0 T_19.575, 10;
+ ; End of false expr.
+    %blend;
+T_19.575;
+    %jmp/1 T_19.573, 9;
+T_19.572 ; End of true expr.
+    %load/vec4 v0x2477060_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_19.580, 10;
+    %load/vec4 v0x2476f80_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_19.582, 11;
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_19.583, 11;
+T_19.582 ; End of true expr.
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_19.583, 11;
+ ; End of false expr.
+    %blend;
+T_19.583;
+    %jmp/1 T_19.581, 10;
+T_19.580 ; End of true expr.
+    %load/vec4 v0x2476f80_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_19.584, 11;
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_19.585, 11;
+T_19.584 ; End of true expr.
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_19.585, 11;
+ ; End of false expr.
+    %blend;
+T_19.585;
+    %jmp/0 T_19.581, 10;
+ ; End of false expr.
+    %blend;
+T_19.581;
+    %jmp/0 T_19.573, 9;
+ ; End of false expr.
+    %blend;
+T_19.573;
+    %jmp/1 T_19.571, 8;
+T_19.570 ; End of true expr.
+    %load/vec4 v0x2477120_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_19.586, 9;
+    %load/vec4 v0x2477060_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_19.588, 10;
+    %load/vec4 v0x2476f80_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_19.590, 11;
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_19.591, 11;
+T_19.590 ; End of true expr.
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_19.591, 11;
+ ; End of false expr.
+    %blend;
+T_19.591;
+    %jmp/1 T_19.589, 10;
+T_19.588 ; End of true expr.
+    %load/vec4 v0x2476f80_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_19.592, 11;
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_19.593, 11;
+T_19.592 ; End of true expr.
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_19.593, 11;
+ ; End of false expr.
+    %blend;
+T_19.593;
+    %jmp/0 T_19.589, 10;
+ ; End of false expr.
+    %blend;
+T_19.589;
+    %jmp/1 T_19.587, 9;
+T_19.586 ; End of true expr.
+    %load/vec4 v0x2477060_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_19.594, 10;
+    %load/vec4 v0x2476f80_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_19.596, 11;
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_19.597, 11;
+T_19.596 ; End of true expr.
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_19.597, 11;
+ ; End of false expr.
+    %blend;
+T_19.597;
+    %jmp/1 T_19.595, 10;
+T_19.594 ; End of true expr.
+    %load/vec4 v0x2476f80_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_19.598, 11;
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_19.599, 11;
+T_19.598 ; End of true expr.
+    %load/vec4 v0x2477390_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_19.599, 11;
+ ; End of false expr.
+    %blend;
+T_19.599;
+    %jmp/0 T_19.595, 10;
+ ; End of false expr.
+    %blend;
+T_19.595;
+    %jmp/0 T_19.587, 9;
+ ; End of false expr.
+    %blend;
+T_19.587;
+    %jmp/0 T_19.571, 8;
+ ; End of false expr.
+    %blend;
+T_19.571;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x24783d0 .scope module, "yosys__39_" "fiftyfivenm_lcell_comb" 3 239, 4 22 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "combout"
+    .port_info 1 /OUTPUT 1 "cout"
+    .port_info 2 /INPUT 1 "dataa"
+    .port_info 3 /INPUT 1 "datab"
+    .port_info 4 /INPUT 1 "datac"
+    .port_info 5 /INPUT 1 "datad"
+    .port_info 6 /INPUT 1 "cin"
+P_0x2478560 .param/str "dont_touch" 0 4 34, "off";
+P_0x24785a0 .param/str "lpm_type" 0 4 35, "fiftyfivenm_lcell_comb";
+P_0x24785e0 .param/l "lut_mask" 0 4 32, C4<1011000010110000>;
+P_0x2478620 .param/str "sum_lutc_input" 0 4 33, "datac";
+L_0x2490b80 .functor BUFZ 1, L_0x248dba0, C4<0>, C4<0>, C4<0>;
+L_0x2490c80 .functor BUFZ 1, L_0x2493340, C4<0>, C4<0>, C4<0>;
+L_0x2490cf0 .functor BUFZ 1, L_0x2490840, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87ade28 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2490df0 .functor BUFZ 1, L_0x7f14f87ade28, C4<0>, C4<0>, C4<0>;
+L_0x7f14f87add98 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2490f20 .functor AND 1, v0x24794e0_0, L_0x7f14f87add98, C4<1>, C4<1>;
+L_0x7f14f87adde0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+L_0x2490ff0 .functor AND 1, v0x2479660_0, L_0x7f14f87adde0, C4<1>, C4<1>;
+v0x2479090_0 .net/2u *"_s12", 0 0, L_0x7f14f87adde0;  1 drivers
+v0x2479190_0 .net/2u *"_s8", 0 0, L_0x7f14f87add98;  1 drivers
+o0x7f14f87fcbb8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2479270_0 .net "cin", 0 0, o0x7f14f87fcbb8;  0 drivers
+o0x7f14f87fcbe8 .functor BUFZ 1, C4<z>; HiZ drive
+v0x2479310_0 .net "cin_w", 0 0, o0x7f14f87fcbe8;  0 drivers
+v0x24793d0_0 .net "combout", 0 0, L_0x2490f20;  1 drivers
+v0x24794e0_0 .var "combout_rt", 0 0;
+v0x24795a0_0 .net "cout", 0 0, L_0x2490ff0;  1 drivers
+v0x2479660_0 .var "cout_rt", 0 0;
+v0x2479720_0 .net "dataa", 0 0, L_0x248dba0;  alias, 1 drivers
+v0x2479850_0 .net "dataa_w", 0 0, L_0x2490b80;  1 drivers
+v0x24798f0_0 .net "datab", 0 0, L_0x2493340;  alias, 1 drivers
+v0x2479990_0 .net "datab_w", 0 0, L_0x2490c80;  1 drivers
+v0x2479a50_0 .net "datac", 0 0, L_0x2490840;  alias, 1 drivers
+v0x2479b20_0 .net "datac_w", 0 0, L_0x2490cf0;  1 drivers
+v0x2479bc0_0 .net "datad", 0 0, L_0x7f14f87ade28;  1 drivers
+v0x2479c80_0 .net "datad_w", 0 0, L_0x2490df0;  1 drivers
+v0x2479d40_0 .var "lut_type", 1 0;
+E_0x2476b70/0 .event edge, v0x2479310_0, v0x2479c80_0, v0x2479b20_0, v0x2479990_0;
+E_0x2476b70/1 .event edge, v0x2479850_0;
+E_0x2476b70 .event/or E_0x2476b70/0, E_0x2476b70/1;
+S_0x24789a0 .scope function.vec4.s1, "lut_data" "lut_data" 4 52, 4 52 0, S_0x24783d0;
+ .timescale 0 0;
+v0x2478ba0_0 .var "dataa", 0 0;
+v0x2478c80_0 .var "datab", 0 0;
+v0x2478d40_0 .var "datac", 0 0;
+v0x2478de0_0 .var "datad", 0 0;
+; Variable lut_data is vec4 return value of scope S_0x24789a0
+v0x2478fb0_0 .var "mask", 15 0;
+TD_tb.U.yosys__39_.lut_data ;
+    %load/vec4 v0x2478de0_0;
+    %flag_set/vec4 8;
+    %jmp/0 T_20.600, 8;
+    %load/vec4 v0x2478d40_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_20.602, 9;
+    %load/vec4 v0x2478c80_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_20.604, 10;
+    %load/vec4 v0x2478ba0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_20.606, 11;
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 15, 5;
+    %jmp/1 T_20.607, 11;
+T_20.606 ; End of true expr.
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 14, 5;
+    %jmp/0 T_20.607, 11;
+ ; End of false expr.
+    %blend;
+T_20.607;
+    %jmp/1 T_20.605, 10;
+T_20.604 ; End of true expr.
+    %load/vec4 v0x2478ba0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_20.608, 11;
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 13, 5;
+    %jmp/1 T_20.609, 11;
+T_20.608 ; End of true expr.
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 12, 5;
+    %jmp/0 T_20.609, 11;
+ ; End of false expr.
+    %blend;
+T_20.609;
+    %jmp/0 T_20.605, 10;
+ ; End of false expr.
+    %blend;
+T_20.605;
+    %jmp/1 T_20.603, 9;
+T_20.602 ; End of true expr.
+    %load/vec4 v0x2478c80_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_20.610, 10;
+    %load/vec4 v0x2478ba0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_20.612, 11;
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 11, 5;
+    %jmp/1 T_20.613, 11;
+T_20.612 ; End of true expr.
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 10, 5;
+    %jmp/0 T_20.613, 11;
+ ; End of false expr.
+    %blend;
+T_20.613;
+    %jmp/1 T_20.611, 10;
+T_20.610 ; End of true expr.
+    %load/vec4 v0x2478ba0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_20.614, 11;
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 9, 5;
+    %jmp/1 T_20.615, 11;
+T_20.614 ; End of true expr.
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 8, 5;
+    %jmp/0 T_20.615, 11;
+ ; End of false expr.
+    %blend;
+T_20.615;
+    %jmp/0 T_20.611, 10;
+ ; End of false expr.
+    %blend;
+T_20.611;
+    %jmp/0 T_20.603, 9;
+ ; End of false expr.
+    %blend;
+T_20.603;
+    %jmp/1 T_20.601, 8;
+T_20.600 ; End of true expr.
+    %load/vec4 v0x2478d40_0;
+    %flag_set/vec4 9;
+    %jmp/0 T_20.616, 9;
+    %load/vec4 v0x2478c80_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_20.618, 10;
+    %load/vec4 v0x2478ba0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_20.620, 11;
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 7, 4;
+    %jmp/1 T_20.621, 11;
+T_20.620 ; End of true expr.
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 6, 4;
+    %jmp/0 T_20.621, 11;
+ ; End of false expr.
+    %blend;
+T_20.621;
+    %jmp/1 T_20.619, 10;
+T_20.618 ; End of true expr.
+    %load/vec4 v0x2478ba0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_20.622, 11;
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 5, 4;
+    %jmp/1 T_20.623, 11;
+T_20.622 ; End of true expr.
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 4, 4;
+    %jmp/0 T_20.623, 11;
+ ; End of false expr.
+    %blend;
+T_20.623;
+    %jmp/0 T_20.619, 10;
+ ; End of false expr.
+    %blend;
+T_20.619;
+    %jmp/1 T_20.617, 9;
+T_20.616 ; End of true expr.
+    %load/vec4 v0x2478c80_0;
+    %flag_set/vec4 10;
+    %jmp/0 T_20.624, 10;
+    %load/vec4 v0x2478ba0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_20.626, 11;
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 3, 3;
+    %jmp/1 T_20.627, 11;
+T_20.626 ; End of true expr.
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 2, 3;
+    %jmp/0 T_20.627, 11;
+ ; End of false expr.
+    %blend;
+T_20.627;
+    %jmp/1 T_20.625, 10;
+T_20.624 ; End of true expr.
+    %load/vec4 v0x2478ba0_0;
+    %flag_set/vec4 11;
+    %jmp/0 T_20.628, 11;
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 1, 2;
+    %jmp/1 T_20.629, 11;
+T_20.628 ; End of true expr.
+    %load/vec4 v0x2478fb0_0;
+    %parti/s 1, 0, 2;
+    %jmp/0 T_20.629, 11;
+ ; End of false expr.
+    %blend;
+T_20.629;
+    %jmp/0 T_20.625, 10;
+ ; End of false expr.
+    %blend;
+T_20.625;
+    %jmp/0 T_20.617, 9;
+ ; End of false expr.
+    %blend;
+T_20.617;
+    %jmp/0 T_20.601, 8;
+ ; End of false expr.
+    %blend;
+T_20.601;
+    %ret/vec4 0, 0, 1;  Assign to lut_data (store_vec4_to_lval)
+    %end;
+S_0x2479fd0 .scope module, "yosys__40_" "fiftyfivenm_io_ibuf" 3 250, 4 10 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "ibar"
+RS_0x7f14f87fcf78 .resolv tri, L_0x2490110, L_0x2491610;
+L_0x2490110 .functor BUFZ 1, RS_0x7f14f87fcf78, C4<0>, C4<0>, C4<0>;
+L_0x24915a0 .functor BUFZ 1, v0x2487700_0, C4<0>, C4<0>, C4<0>;
+v0x247a1d0_0 .net "i", 0 0, v0x2487700_0;  alias, 1 drivers
+v0x247a2b0_0 .net8 "ibar", 0 0, RS_0x7f14f87fcf78;  2 drivers
+v0x247a370_0 .net "o", 0 0, L_0x24915a0;  alias, 1 drivers
+S_0x247a4c0 .scope module, "yosys__41_" "fiftyfivenm_io_obuf" 3 257, 4 16 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "oe"
+L_0x24916d0 .functor BUFZ 1, L_0x2491800, C4<0>, C4<0>, C4<0>;
+RS_0x7f14f87fd0c8 .resolv tri, L_0x2491740, L_0x24918f0;
+L_0x2491740 .functor BUFZ 1, RS_0x7f14f87fd0c8, C4<0>, C4<0>, C4<0>;
+v0x247a6f0_0 .net "i", 0 0, L_0x2491800;  1 drivers
+v0x247a7d0_0 .net "o", 0 0, L_0x24916d0;  1 drivers
+v0x247a890_0 .net8 "oe", 0 0, RS_0x7f14f87fd0c8;  2 drivers
+S_0x247a9e0 .scope module, "yosys__42_" "fiftyfivenm_io_obuf" 3 264, 4 16 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "oe"
+L_0x24919b0 .functor BUFZ 1, L_0x2491ae0, C4<0>, C4<0>, C4<0>;
+RS_0x7f14f87fd1e8 .resolv tri, L_0x2491a20, L_0x2491470;
+L_0x2491a20 .functor BUFZ 1, RS_0x7f14f87fd1e8, C4<0>, C4<0>, C4<0>;
+v0x247ac10_0 .net "i", 0 0, L_0x2491ae0;  1 drivers
+v0x247acf0_0 .net "o", 0 0, L_0x24919b0;  1 drivers
+v0x247adb0_0 .net8 "oe", 0 0, RS_0x7f14f87fd1e8;  2 drivers
+S_0x247af00 .scope module, "yosys__43_" "fiftyfivenm_io_obuf" 3 271, 4 16 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "oe"
+L_0x2491530 .functor BUFZ 1, L_0x2491dd0, C4<0>, C4<0>, C4<0>;
+RS_0x7f14f87fd308 .resolv tri, L_0x2491d10, L_0x2491ec0;
+L_0x2491d10 .functor BUFZ 1, RS_0x7f14f87fd308, C4<0>, C4<0>, C4<0>;
+v0x247b130_0 .net "i", 0 0, L_0x2491dd0;  1 drivers
+v0x247b210_0 .net "o", 0 0, L_0x2491530;  1 drivers
+v0x247b2d0_0 .net8 "oe", 0 0, RS_0x7f14f87fd308;  2 drivers
+S_0x247b420 .scope module, "yosys__44_" "fiftyfivenm_io_obuf" 3 278, 4 16 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "oe"
+L_0x2491f80 .functor BUFZ 1, L_0x24920b0, C4<0>, C4<0>, C4<0>;
+RS_0x7f14f87fd428 .resolv tri, L_0x2491ff0, L_0x2491bd0;
+L_0x2491ff0 .functor BUFZ 1, RS_0x7f14f87fd428, C4<0>, C4<0>, C4<0>;
+v0x247b650_0 .net "i", 0 0, L_0x24920b0;  1 drivers
+v0x247b730_0 .net "o", 0 0, L_0x2491f80;  1 drivers
+v0x247b7f0_0 .net8 "oe", 0 0, RS_0x7f14f87fd428;  2 drivers
+S_0x247b940 .scope module, "yosys__45_" "fiftyfivenm_io_obuf" 3 285, 4 16 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "oe"
+L_0x2491c90 .functor BUFZ 1, L_0x24923b0, C4<0>, C4<0>, C4<0>;
+RS_0x7f14f87fd548 .resolv tri, L_0x24922f0, L_0x24924a0;
+L_0x24922f0 .functor BUFZ 1, RS_0x7f14f87fd548, C4<0>, C4<0>, C4<0>;
+v0x247bb70_0 .net "i", 0 0, L_0x24923b0;  1 drivers
+v0x247bc50_0 .net "o", 0 0, L_0x2491c90;  1 drivers
+v0x247bd10_0 .net8 "oe", 0 0, RS_0x7f14f87fd548;  2 drivers
+S_0x247be60 .scope module, "yosys__46_" "fiftyfivenm_io_obuf" 3 292, 4 16 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "oe"
+L_0x2492560 .functor BUFZ 1, L_0x2492690, C4<0>, C4<0>, C4<0>;
+RS_0x7f14f87fd668 .resolv tri, L_0x24925d0, L_0x24921a0;
+L_0x24925d0 .functor BUFZ 1, RS_0x7f14f87fd668, C4<0>, C4<0>, C4<0>;
+v0x247c090_0 .net "i", 0 0, L_0x2492690;  1 drivers
+v0x247c170_0 .net "o", 0 0, L_0x2492560;  1 drivers
+v0x247c230_0 .net8 "oe", 0 0, RS_0x7f14f87fd668;  2 drivers
+S_0x247c380 .scope module, "yosys__47_" "fiftyfivenm_io_obuf" 3 299, 4 16 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "oe"
+L_0x2492260 .functor BUFZ 1, L_0x24929a0, C4<0>, C4<0>, C4<0>;
+RS_0x7f14f87fd788 .resolv tri, L_0x24928e0, L_0x2492a90;
+L_0x24928e0 .functor BUFZ 1, RS_0x7f14f87fd788, C4<0>, C4<0>, C4<0>;
+v0x247c5b0_0 .net "i", 0 0, L_0x24929a0;  1 drivers
+v0x247c690_0 .net "o", 0 0, L_0x2492260;  1 drivers
+v0x247c750_0 .net8 "oe", 0 0, RS_0x7f14f87fd788;  2 drivers
+S_0x247c8a0 .scope module, "yosys__48_" "fiftyfivenm_io_obuf" 3 306, 4 16 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "oe"
+L_0x2492ba0 .functor BUFZ 1, L_0x2492780, C4<0>, C4<0>, C4<0>;
+RS_0x7f14f87fd8a8 .resolv tri, L_0x2492c10, L_0x2492870;
+L_0x2492c10 .functor BUFZ 1, RS_0x7f14f87fd8a8, C4<0>, C4<0>, C4<0>;
+v0x247cad0_0 .net "i", 0 0, L_0x2492780;  1 drivers
+v0x247cbb0_0 .net "o", 0 0, L_0x2492ba0;  1 drivers
+v0x247cc70_0 .net8 "oe", 0 0, RS_0x7f14f87fd8a8;  2 drivers
+S_0x247cdc0 .scope module, "yosys__49_" "fiftyfivenm_io_ibuf" 3 313, 4 10 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "ibar"
+RS_0x7f14f87fd998 .resolv tri, L_0x2493280, L_0x24933b0;
+L_0x2493280 .functor BUFZ 1, RS_0x7f14f87fd998, C4<0>, C4<0>, C4<0>;
+L_0x2493340 .functor BUFZ 1, v0x24878d0_0, C4<0>, C4<0>, C4<0>;
+v0x247cff0_0 .net "i", 0 0, v0x24878d0_0;  alias, 1 drivers
+v0x247d0d0_0 .net8 "ibar", 0 0, RS_0x7f14f87fd998;  2 drivers
+v0x247d190_0 .net "o", 0 0, L_0x2493340;  alias, 1 drivers
+S_0x247d2c0 .scope module, "yosys__50_" "fiftyfivenm_io_obuf" 3 320, 4 16 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "oe"
+L_0x24934d0 .functor BUFZ 1, L_0x248ed00, C4<0>, C4<0>, C4<0>;
+RS_0x7f14f87fda88 .resolv tri, L_0x24935d0, L_0x2493640;
+L_0x24935d0 .functor BUFZ 1, RS_0x7f14f87fda88, C4<0>, C4<0>, C4<0>;
+v0x247d4f0_0 .net "i", 0 0, L_0x248ed00;  alias, 1 drivers
+v0x247d5e0_0 .net "o", 0 0, L_0x24934d0;  alias, 1 drivers
+v0x247d680_0 .net8 "oe", 0 0, RS_0x7f14f87fda88;  2 drivers
+S_0x247d7d0 .scope module, "yosys__51_" "fiftyfivenm_io_ibuf" 3 327, 4 10 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "ibar"
+RS_0x7f14f87fdb78 .resolv tri, L_0x24936b0, L_0x24937e0;
+L_0x24936b0 .functor BUFZ 1, RS_0x7f14f87fdb78, C4<0>, C4<0>, C4<0>;
+L_0x2493770 .functor BUFZ 1, v0x2487ab0_0, C4<0>, C4<0>, C4<0>;
+v0x24714b0_0 .net "i", 0 0, v0x2487ab0_0;  alias, 1 drivers
+v0x247dbe0_0 .net8 "ibar", 0 0, RS_0x7f14f87fdb78;  2 drivers
+v0x247dca0_0 .net "o", 0 0, L_0x2493770;  alias, 1 drivers
+S_0x247de80 .scope module, "yosys__52_" "fiftyfivenm_io_ibuf" 3 334, 4 10 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "o"
+    .port_info 1 /INPUT 1 "i"
+    .port_info 2 /INPUT 1 "ibar"
+RS_0x7f14f87fdc68 .resolv tri, L_0x2493910, L_0x2493a40;
+L_0x2493910 .functor BUFZ 1, RS_0x7f14f87fdc68, C4<0>, C4<0>, C4<0>;
+L_0x24939d0 .functor BUFZ 1, v0x2487bf0_0, C4<0>, C4<0>, C4<0>;
+v0x247e0b0_0 .net "i", 0 0, v0x2487bf0_0;  alias, 1 drivers
+v0x247e170_0 .net8 "ibar", 0 0, RS_0x7f14f87fdc68;  2 drivers
+v0x247e250_0 .net "o", 0 0, L_0x24939d0;  alias, 1 drivers
+S_0x247e350 .scope module, "yosys__53_" "dffeas" 3 340, 4 93 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "q"
+    .port_info 1 /INPUT 1 "d"
+    .port_info 2 /INPUT 1 "clk"
+    .port_info 3 /INPUT 1 "clrn"
+    .port_info 4 /INPUT 1 "prn"
+    .port_info 5 /INPUT 1 "ena"
+    .port_info 6 /INPUT 1 "asdata"
+    .port_info 7 /INPUT 1 "aload"
+    .port_info 8 /INPUT 1 "sclr"
+    .port_info 9 /INPUT 1 "sload"
+P_0x247e530 .param/str "is_wysiwyg" 0 4 93, "TRUE";
+P_0x247e570 .param/str "power_up" 0 4 93, "dontcare";
+L_0x7f14f87ae338 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x247e880_0 .net "aload", 0 0, L_0x7f14f87ae338;  1 drivers
+L_0x7f14f87ae2f0 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x247e960_0 .net "asdata", 0 0, L_0x7f14f87ae2f0;  1 drivers
+v0x247ea20_0 .net "clk", 0 0, L_0x24915a0;  alias, 1 drivers
+L_0x7f14f87ae218 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x247eac0_0 .net "clrn", 0 0, L_0x7f14f87ae218;  1 drivers
+v0x247eb60_0 .net "d", 0 0, L_0x2493b00;  1 drivers
+L_0x7f14f87ae2a8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x247ec50_0 .net "ena", 0 0, L_0x7f14f87ae2a8;  1 drivers
+L_0x7f14f87ae260 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x247ed10_0 .net "prn", 0 0, L_0x7f14f87ae260;  1 drivers
+v0x247edd0_0 .var "q", 0 0;
+L_0x7f14f87ae380 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x247ee90_0 .net "sclr", 0 0, L_0x7f14f87ae380;  1 drivers
+L_0x7f14f87ae3c8 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x247efe0_0 .net "sload", 0 0, L_0x7f14f87ae3c8;  1 drivers
+E_0x2478790 .event posedge, v0x247a370_0;
+S_0x247f240 .scope module, "yosys__54_" "dffeas" 3 354, 4 93 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "q"
+    .port_info 1 /INPUT 1 "d"
+    .port_info 2 /INPUT 1 "clk"
+    .port_info 3 /INPUT 1 "clrn"
+    .port_info 4 /INPUT 1 "prn"
+    .port_info 5 /INPUT 1 "ena"
+    .port_info 6 /INPUT 1 "asdata"
+    .port_info 7 /INPUT 1 "aload"
+    .port_info 8 /INPUT 1 "sclr"
+    .port_info 9 /INPUT 1 "sload"
+P_0x247f3d0 .param/str "is_wysiwyg" 0 4 93, "TRUE";
+P_0x247f410 .param/str "power_up" 0 4 93, "dontcare";
+L_0x7f14f87ae530 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x247f670_0 .net "aload", 0 0, L_0x7f14f87ae530;  1 drivers
+L_0x7f14f87ae4e8 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x247f750_0 .net "asdata", 0 0, L_0x7f14f87ae4e8;  1 drivers
+v0x247f810_0 .net "clk", 0 0, L_0x24915a0;  alias, 1 drivers
+L_0x7f14f87ae410 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x247f900_0 .net "clrn", 0 0, L_0x7f14f87ae410;  1 drivers
+v0x247f9a0_0 .net "d", 0 0, L_0x24930c0;  1 drivers
+L_0x7f14f87ae4a0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x247fab0_0 .net "ena", 0 0, L_0x7f14f87ae4a0;  1 drivers
+L_0x7f14f87ae458 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x247fb70_0 .net "prn", 0 0, L_0x7f14f87ae458;  1 drivers
+v0x247fc30_0 .var "q", 0 0;
+L_0x7f14f87ae578 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x247fcf0_0 .net "sclr", 0 0, L_0x7f14f87ae578;  1 drivers
+L_0x7f14f87ae5c0 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x247fe40_0 .net "sload", 0 0, L_0x7f14f87ae5c0;  1 drivers
+S_0x24800a0 .scope module, "yosys__55_" "dffeas" 3 368, 4 93 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "q"
+    .port_info 1 /INPUT 1 "d"
+    .port_info 2 /INPUT 1 "clk"
+    .port_info 3 /INPUT 1 "clrn"
+    .port_info 4 /INPUT 1 "prn"
+    .port_info 5 /INPUT 1 "ena"
+    .port_info 6 /INPUT 1 "asdata"
+    .port_info 7 /INPUT 1 "aload"
+    .port_info 8 /INPUT 1 "sclr"
+    .port_info 9 /INPUT 1 "sload"
+P_0x2480230 .param/str "is_wysiwyg" 0 4 93, "TRUE";
+P_0x2480270 .param/str "power_up" 0 4 93, "dontcare";
+L_0x7f14f87ae728 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x24804a0_0 .net "aload", 0 0, L_0x7f14f87ae728;  1 drivers
+L_0x7f14f87ae6e0 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2480580_0 .net "asdata", 0 0, L_0x7f14f87ae6e0;  1 drivers
+v0x2480640_0 .net "clk", 0 0, L_0x24915a0;  alias, 1 drivers
+L_0x7f14f87ae608 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x24806e0_0 .net "clrn", 0 0, L_0x7f14f87ae608;  1 drivers
+v0x2480780_0 .net "d", 0 0, L_0x248d7f0;  1 drivers
+L_0x7f14f87ae698 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2480890_0 .net "ena", 0 0, L_0x7f14f87ae698;  1 drivers
+L_0x7f14f87ae650 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2480950_0 .net "prn", 0 0, L_0x7f14f87ae650;  1 drivers
+v0x2480a10_0 .var "q", 0 0;
+L_0x7f14f87ae770 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2480ad0_0 .net "sclr", 0 0, L_0x7f14f87ae770;  1 drivers
+L_0x7f14f87ae7b8 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2480c20_0 .net "sload", 0 0, L_0x7f14f87ae7b8;  1 drivers
+S_0x2480e80 .scope module, "yosys__56_" "dffeas" 3 382, 4 93 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "q"
+    .port_info 1 /INPUT 1 "d"
+    .port_info 2 /INPUT 1 "clk"
+    .port_info 3 /INPUT 1 "clrn"
+    .port_info 4 /INPUT 1 "prn"
+    .port_info 5 /INPUT 1 "ena"
+    .port_info 6 /INPUT 1 "asdata"
+    .port_info 7 /INPUT 1 "aload"
+    .port_info 8 /INPUT 1 "sclr"
+    .port_info 9 /INPUT 1 "sload"
+P_0x2481010 .param/str "is_wysiwyg" 0 4 93, "TRUE";
+P_0x2481050 .param/str "power_up" 0 4 93, "dontcare";
+L_0x7f14f87ae920 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2481280_0 .net "aload", 0 0, L_0x7f14f87ae920;  1 drivers
+L_0x7f14f87ae8d8 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2481360_0 .net "asdata", 0 0, L_0x7f14f87ae8d8;  1 drivers
+v0x2481420_0 .net "clk", 0 0, L_0x24915a0;  alias, 1 drivers
+L_0x7f14f87ae800 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2481550_0 .net "clrn", 0 0, L_0x7f14f87ae800;  1 drivers
+v0x24815f0_0 .net "d", 0 0, L_0x2493c20;  1 drivers
+L_0x7f14f87ae890 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x24816b0_0 .net "ena", 0 0, L_0x7f14f87ae890;  1 drivers
+L_0x7f14f87ae848 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2481770_0 .net "prn", 0 0, L_0x7f14f87ae848;  1 drivers
+v0x2481830_0 .var "q", 0 0;
+L_0x7f14f87ae968 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x24818f0_0 .net "sclr", 0 0, L_0x7f14f87ae968;  1 drivers
+L_0x7f14f87ae9b0 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2481a40_0 .net "sload", 0 0, L_0x7f14f87ae9b0;  1 drivers
+S_0x2481ca0 .scope module, "yosys__57_" "dffeas" 3 396, 4 93 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "q"
+    .port_info 1 /INPUT 1 "d"
+    .port_info 2 /INPUT 1 "clk"
+    .port_info 3 /INPUT 1 "clrn"
+    .port_info 4 /INPUT 1 "prn"
+    .port_info 5 /INPUT 1 "ena"
+    .port_info 6 /INPUT 1 "asdata"
+    .port_info 7 /INPUT 1 "aload"
+    .port_info 8 /INPUT 1 "sclr"
+    .port_info 9 /INPUT 1 "sload"
+P_0x2481e30 .param/str "is_wysiwyg" 0 4 93, "TRUE";
+P_0x2481e70 .param/str "power_up" 0 4 93, "dontcare";
+L_0x7f14f87aeb18 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x24820a0_0 .net "aload", 0 0, L_0x7f14f87aeb18;  1 drivers
+L_0x7f14f87aead0 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2482180_0 .net "asdata", 0 0, L_0x7f14f87aead0;  1 drivers
+v0x2482240_0 .net "clk", 0 0, L_0x24915a0;  alias, 1 drivers
+L_0x7f14f87ae9f8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x24822e0_0 .net "clrn", 0 0, L_0x7f14f87ae9f8;  1 drivers
+v0x2482380_0 .net "d", 0 0, L_0x2494400;  1 drivers
+L_0x7f14f87aea88 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2482490_0 .net "ena", 0 0, L_0x7f14f87aea88;  1 drivers
+L_0x7f14f87aea40 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2482550_0 .net "prn", 0 0, L_0x7f14f87aea40;  1 drivers
+v0x2482610_0 .var "q", 0 0;
+L_0x7f14f87aeb60 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x24826d0_0 .net "sclr", 0 0, L_0x7f14f87aeb60;  1 drivers
+L_0x7f14f87aeba8 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2482820_0 .net "sload", 0 0, L_0x7f14f87aeba8;  1 drivers
+S_0x2482a80 .scope module, "yosys__58_" "dffeas" 3 410, 4 93 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "q"
+    .port_info 1 /INPUT 1 "d"
+    .port_info 2 /INPUT 1 "clk"
+    .port_info 3 /INPUT 1 "clrn"
+    .port_info 4 /INPUT 1 "prn"
+    .port_info 5 /INPUT 1 "ena"
+    .port_info 6 /INPUT 1 "asdata"
+    .port_info 7 /INPUT 1 "aload"
+    .port_info 8 /INPUT 1 "sclr"
+    .port_info 9 /INPUT 1 "sload"
+P_0x2482c10 .param/str "is_wysiwyg" 0 4 93, "TRUE";
+P_0x2482c50 .param/str "power_up" 0 4 93, "dontcare";
+L_0x7f14f87aed10 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2482e80_0 .net "aload", 0 0, L_0x7f14f87aed10;  1 drivers
+L_0x7f14f87aecc8 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2482f60_0 .net "asdata", 0 0, L_0x7f14f87aecc8;  1 drivers
+v0x2483020_0 .net "clk", 0 0, L_0x24915a0;  alias, 1 drivers
+L_0x7f14f87aebf0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x24830c0_0 .net "clrn", 0 0, L_0x7f14f87aebf0;  1 drivers
+v0x2483160_0 .net "d", 0 0, L_0x2494670;  1 drivers
+L_0x7f14f87aec80 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2483270_0 .net "ena", 0 0, L_0x7f14f87aec80;  1 drivers
+L_0x7f14f87aec38 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2483330_0 .net "prn", 0 0, L_0x7f14f87aec38;  1 drivers
+v0x24833f0_0 .var "q", 0 0;
+L_0x7f14f87aed58 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x24834b0_0 .net "sclr", 0 0, L_0x7f14f87aed58;  1 drivers
+L_0x7f14f87aeda0 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2483600_0 .net "sload", 0 0, L_0x7f14f87aeda0;  1 drivers
+S_0x2483860 .scope module, "yosys__59_" "dffeas" 3 424, 4 93 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "q"
+    .port_info 1 /INPUT 1 "d"
+    .port_info 2 /INPUT 1 "clk"
+    .port_info 3 /INPUT 1 "clrn"
+    .port_info 4 /INPUT 1 "prn"
+    .port_info 5 /INPUT 1 "ena"
+    .port_info 6 /INPUT 1 "asdata"
+    .port_info 7 /INPUT 1 "aload"
+    .port_info 8 /INPUT 1 "sclr"
+    .port_info 9 /INPUT 1 "sload"
+P_0x24839f0 .param/str "is_wysiwyg" 0 4 93, "TRUE";
+P_0x2483a30 .param/str "power_up" 0 4 93, "dontcare";
+L_0x7f14f87aef08 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2483c60_0 .net "aload", 0 0, L_0x7f14f87aef08;  1 drivers
+L_0x7f14f87aeec0 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2483d40_0 .net "asdata", 0 0, L_0x7f14f87aeec0;  1 drivers
+v0x2483e00_0 .net "clk", 0 0, L_0x24915a0;  alias, 1 drivers
+L_0x7f14f87aede8 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2483ea0_0 .net "clrn", 0 0, L_0x7f14f87aede8;  1 drivers
+v0x2483f40_0 .net "d", 0 0, L_0x2494860;  1 drivers
+L_0x7f14f87aee78 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2484050_0 .net "ena", 0 0, L_0x7f14f87aee78;  1 drivers
+L_0x7f14f87aee30 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2484110_0 .net "prn", 0 0, L_0x7f14f87aee30;  1 drivers
+v0x24841d0_0 .var "q", 0 0;
+L_0x7f14f87aef50 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2484290_0 .net "sclr", 0 0, L_0x7f14f87aef50;  1 drivers
+L_0x7f14f87aef98 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x24843e0_0 .net "sload", 0 0, L_0x7f14f87aef98;  1 drivers
+S_0x2484640 .scope module, "yosys__60_" "dffeas" 3 438, 4 93 0, S_0x243bc60;
+ .timescale 0 0;
+    .port_info 0 /OUTPUT 1 "q"
+    .port_info 1 /INPUT 1 "d"
+    .port_info 2 /INPUT 1 "clk"
+    .port_info 3 /INPUT 1 "clrn"
+    .port_info 4 /INPUT 1 "prn"
+    .port_info 5 /INPUT 1 "ena"
+    .port_info 6 /INPUT 1 "asdata"
+    .port_info 7 /INPUT 1 "aload"
+    .port_info 8 /INPUT 1 "sclr"
+    .port_info 9 /INPUT 1 "sload"
+P_0x24847d0 .param/str "is_wysiwyg" 0 4 93, "TRUE";
+P_0x2484810 .param/str "power_up" 0 4 93, "dontcare";
+L_0x7f14f87af100 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2484a40_0 .net "aload", 0 0, L_0x7f14f87af100;  1 drivers
+L_0x7f14f87af0b8 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2484b20_0 .net "asdata", 0 0, L_0x7f14f87af0b8;  1 drivers
+v0x2484be0_0 .net "clk", 0 0, L_0x24915a0;  alias, 1 drivers
+L_0x7f14f87aefe0 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2484d90_0 .net "clrn", 0 0, L_0x7f14f87aefe0;  1 drivers
+v0x2484e30_0 .net "d", 0 0, L_0x2494d40;  1 drivers
+L_0x7f14f87af070 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2484ed0_0 .net "ena", 0 0, L_0x7f14f87af070;  1 drivers
+L_0x7f14f87af028 .functor BUFT 1, C4<1>, C4<0>, C4<0>, C4<0>;
+v0x2484f70_0 .net "prn", 0 0, L_0x7f14f87af028;  1 drivers
+v0x2485030_0 .var "q", 0 0;
+L_0x7f14f87af148 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x24850f0_0 .net "sclr", 0 0, L_0x7f14f87af148;  1 drivers
+L_0x7f14f87af190 .functor BUFT 1, C4<0>, C4<0>, C4<0>, C4<0>;
+v0x2485240_0 .net "sload", 0 0, L_0x7f14f87af190;  1 drivers
+    .scope S_0x23b9a90;
+T_21 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2407260_0, 0, 2;
+    %end;
+    .thread T_21;
+    .scope S_0x23b9a90;
+T_22 ;
+    %wait E_0x2446170;
+    %load/vec4 v0x2407260_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_22.0, 4;
+    %pushi/vec4 257, 0, 16;
+    %load/vec4 v0x23b7490_0;
+    %load/vec4 v0x244bad0_0;
+    %load/vec4 v0x240dfe0_0;
+    %load/vec4 v0x240dc00_0;
+    %store/vec4 v0x23bd7c0_0, 0, 1;
+    %store/vec4 v0x23bd6f0_0, 0, 1;
+    %store/vec4 v0x23bdb90_0, 0, 1;
+    %store/vec4 v0x2452050_0, 0, 1;
+    %store/vec4 v0x23be920_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__19_.lut_data, S_0x2447330;
+    %store/vec4 v0x23b6990_0, 0, 1;
+    %jmp T_22.1;
+T_22.0 ;
+    %load/vec4 v0x2407260_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_22.2, 4;
+    %pushi/vec4 257, 0, 16;
+    %load/vec4 v0x23b7490_0;
+    %load/vec4 v0x244bad0_0;
+    %load/vec4 v0x23b6d50_0;
+    %load/vec4 v0x240dc00_0;
+    %store/vec4 v0x23bd7c0_0, 0, 1;
+    %store/vec4 v0x23bd6f0_0, 0, 1;
+    %store/vec4 v0x23bdb90_0, 0, 1;
+    %store/vec4 v0x2452050_0, 0, 1;
+    %store/vec4 v0x23be920_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__19_.lut_data, S_0x2447330;
+    %store/vec4 v0x23b6990_0, 0, 1;
+T_22.2 ;
+T_22.1 ;
+    %pushi/vec4 257, 0, 16;
+    %load/vec4 v0x23b7490_0;
+    %load/vec4 v0x244bad0_0;
+    %load/vec4 v0x23b6d50_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x23bd7c0_0, 0, 1;
+    %store/vec4 v0x23bd6f0_0, 0, 1;
+    %store/vec4 v0x23bdb90_0, 0, 1;
+    %store/vec4 v0x2452050_0, 0, 1;
+    %store/vec4 v0x23be920_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__19_.lut_data, S_0x2447330;
+    %store/vec4 v0x23b7be0_0, 0, 1;
+    %jmp T_22;
+    .thread T_22, $push;
+    .scope S_0x23ed6e0;
+T_23 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x244c0d0_0, 0, 2;
+    %end;
+    .thread T_23;
+    .scope S_0x23ed6e0;
+T_24 ;
+    %wait E_0x243aee0;
+    %load/vec4 v0x244c0d0_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_24.0, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x24507f0_0;
+    %load/vec4 v0x244e340_0;
+    %load/vec4 v0x244e4a0_0;
+    %load/vec4 v0x244c010_0;
+    %store/vec4 v0x24570a0_0, 0, 1;
+    %store/vec4 v0x2457000_0, 0, 1;
+    %store/vec4 v0x23d3c40_0, 0, 1;
+    %store/vec4 v0x242e630_0, 0, 1;
+    %store/vec4 v0x2457270_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__20_.lut_data, S_0x243e710;
+    %store/vec4 v0x2452ab0_0, 0, 1;
+    %jmp T_24.1;
+T_24.0 ;
+    %load/vec4 v0x244c0d0_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_24.2, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x24507f0_0;
+    %load/vec4 v0x244e340_0;
+    %load/vec4 v0x2454f50_0;
+    %load/vec4 v0x244c010_0;
+    %store/vec4 v0x24570a0_0, 0, 1;
+    %store/vec4 v0x2457000_0, 0, 1;
+    %store/vec4 v0x23d3c40_0, 0, 1;
+    %store/vec4 v0x242e630_0, 0, 1;
+    %store/vec4 v0x2457270_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__20_.lut_data, S_0x243e710;
+    %store/vec4 v0x2452ab0_0, 0, 1;
+T_24.2 ;
+T_24.1 ;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x24507f0_0;
+    %load/vec4 v0x244e340_0;
+    %load/vec4 v0x2454f50_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x24570a0_0, 0, 1;
+    %store/vec4 v0x2457000_0, 0, 1;
+    %store/vec4 v0x23d3c40_0, 0, 1;
+    %store/vec4 v0x242e630_0, 0, 1;
+    %store/vec4 v0x2457270_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__20_.lut_data, S_0x243e710;
+    %store/vec4 v0x2450670_0, 0, 1;
+    %jmp T_24;
+    .thread T_24, $push;
+    .scope S_0x2449ce0;
+T_25 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x235c340_0, 0, 2;
+    %end;
+    .thread T_25;
+    .scope S_0x2449ce0;
+T_26 ;
+    %wait E_0x23b7430;
+    %load/vec4 v0x235c340_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_26.0, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x235c870_0;
+    %load/vec4 v0x235c9f0_0;
+    %load/vec4 v0x235c100_0;
+    %load/vec4 v0x235c280_0;
+    %store/vec4 v0x23d3ff0_0, 0, 1;
+    %store/vec4 v0x23d3f50_0, 0, 1;
+    %store/vec4 v0x24078d0_0, 0, 1;
+    %store/vec4 v0x23edcc0_0, 0, 1;
+    %store/vec4 v0x23d41c0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__21_.lut_data, S_0x23edac0;
+    %store/vec4 v0x243ac00_0, 0, 1;
+    %jmp T_26.1;
+T_26.0 ;
+    %load/vec4 v0x235c340_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_26.2, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x235c870_0;
+    %load/vec4 v0x235c9f0_0;
+    %load/vec4 v0x23c7400_0;
+    %load/vec4 v0x235c280_0;
+    %store/vec4 v0x23d3ff0_0, 0, 1;
+    %store/vec4 v0x23d3f50_0, 0, 1;
+    %store/vec4 v0x24078d0_0, 0, 1;
+    %store/vec4 v0x23edcc0_0, 0, 1;
+    %store/vec4 v0x23d41c0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__21_.lut_data, S_0x23edac0;
+    %store/vec4 v0x243ac00_0, 0, 1;
+T_26.2 ;
+T_26.1 ;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x235c870_0;
+    %load/vec4 v0x235c9f0_0;
+    %load/vec4 v0x23c7400_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x23d3ff0_0, 0, 1;
+    %store/vec4 v0x23d3f50_0, 0, 1;
+    %store/vec4 v0x24078d0_0, 0, 1;
+    %store/vec4 v0x23edcc0_0, 0, 1;
+    %store/vec4 v0x23d41c0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__21_.lut_data, S_0x23edac0;
+    %store/vec4 v0x243ad40_0, 0, 1;
+    %jmp T_26;
+    .thread T_26, $push;
+    .scope S_0x23671c0;
+T_27 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x245be00_0, 0, 2;
+    %end;
+    .thread T_27;
+    .scope S_0x23671c0;
+T_28 ;
+    %wait E_0x24076c0;
+    %load/vec4 v0x245be00_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_28.0, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x2341ad0_0;
+    %load/vec4 v0x245bae0_0;
+    %load/vec4 v0x245bc20_0;
+    %load/vec4 v0x245bd60_0;
+    %store/vec4 v0x235ea60_0, 0, 1;
+    %store/vec4 v0x235d1a0_0, 0, 1;
+    %store/vec4 v0x235df80_0, 0, 1;
+    %store/vec4 v0x235dea0_0, 0, 1;
+    %store/vec4 v0x235ebe0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__22_.lut_data, S_0x235dca0;
+    %store/vec4 v0x23449e0_0, 0, 1;
+    %jmp T_28.1;
+T_28.0 ;
+    %load/vec4 v0x245be00_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_28.2, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x2341ad0_0;
+    %load/vec4 v0x245bae0_0;
+    %load/vec4 v0x2344810_0;
+    %load/vec4 v0x245bd60_0;
+    %store/vec4 v0x235ea60_0, 0, 1;
+    %store/vec4 v0x235d1a0_0, 0, 1;
+    %store/vec4 v0x235df80_0, 0, 1;
+    %store/vec4 v0x235dea0_0, 0, 1;
+    %store/vec4 v0x235ebe0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__22_.lut_data, S_0x235dca0;
+    %store/vec4 v0x23449e0_0, 0, 1;
+T_28.2 ;
+T_28.1 ;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x2341ad0_0;
+    %load/vec4 v0x245bae0_0;
+    %load/vec4 v0x2344810_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x235ea60_0, 0, 1;
+    %store/vec4 v0x235d1a0_0, 0, 1;
+    %store/vec4 v0x235df80_0, 0, 1;
+    %store/vec4 v0x235dea0_0, 0, 1;
+    %store/vec4 v0x235ebe0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__22_.lut_data, S_0x235dca0;
+    %store/vec4 v0x2341950_0, 0, 1;
+    %jmp T_28;
+    .thread T_28, $push;
+    .scope S_0x245c050;
+T_29 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x245da00_0, 0, 2;
+    %end;
+    .thread T_29;
+    .scope S_0x245c050;
+T_30 ;
+    %wait E_0x2367460;
+    %load/vec4 v0x245da00_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_30.0, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x245d4d0_0;
+    %load/vec4 v0x245d650_0;
+    %load/vec4 v0x245d7e0_0;
+    %load/vec4 v0x245d940_0;
+    %store/vec4 v0x245ca80_0, 0, 1;
+    %store/vec4 v0x245c9e0_0, 0, 1;
+    %store/vec4 v0x245c920_0, 0, 1;
+    %store/vec4 v0x245c840_0, 0, 1;
+    %store/vec4 v0x245cc50_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__23_.lut_data, S_0x245c640;
+    %store/vec4 v0x245d160_0, 0, 1;
+    %jmp T_30.1;
+T_30.0 ;
+    %load/vec4 v0x245da00_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_30.2, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x245d4d0_0;
+    %load/vec4 v0x245d650_0;
+    %load/vec4 v0x245cfb0_0;
+    %load/vec4 v0x245d940_0;
+    %store/vec4 v0x245ca80_0, 0, 1;
+    %store/vec4 v0x245c9e0_0, 0, 1;
+    %store/vec4 v0x245c920_0, 0, 1;
+    %store/vec4 v0x245c840_0, 0, 1;
+    %store/vec4 v0x245cc50_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__23_.lut_data, S_0x245c640;
+    %store/vec4 v0x245d160_0, 0, 1;
+T_30.2 ;
+T_30.1 ;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x245d4d0_0;
+    %load/vec4 v0x245d650_0;
+    %load/vec4 v0x245cfb0_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x245ca80_0, 0, 1;
+    %store/vec4 v0x245c9e0_0, 0, 1;
+    %store/vec4 v0x245c920_0, 0, 1;
+    %store/vec4 v0x245c840_0, 0, 1;
+    %store/vec4 v0x245cc50_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__23_.lut_data, S_0x245c640;
+    %store/vec4 v0x245d2c0_0, 0, 1;
+    %jmp T_30;
+    .thread T_30, $push;
+    .scope S_0x245dc90;
+T_31 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x245f680_0, 0, 2;
+    %end;
+    .thread T_31;
+    .scope S_0x245dc90;
+T_32 ;
+    %wait E_0x245c430;
+    %load/vec4 v0x245f680_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_32.0, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x245f130_0;
+    %load/vec4 v0x245f2b0_0;
+    %load/vec4 v0x245f410_0;
+    %load/vec4 v0x245f5c0_0;
+    %store/vec4 v0x245e6a0_0, 0, 1;
+    %store/vec4 v0x245e600_0, 0, 1;
+    %store/vec4 v0x245e540_0, 0, 1;
+    %store/vec4 v0x245e460_0, 0, 1;
+    %store/vec4 v0x245e870_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__24_.lut_data, S_0x245e260;
+    %store/vec4 v0x245eda0_0, 0, 1;
+    %jmp T_32.1;
+T_32.0 ;
+    %load/vec4 v0x245f680_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_32.2, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x245f130_0;
+    %load/vec4 v0x245f2b0_0;
+    %load/vec4 v0x245ebd0_0;
+    %load/vec4 v0x245f5c0_0;
+    %store/vec4 v0x245e6a0_0, 0, 1;
+    %store/vec4 v0x245e600_0, 0, 1;
+    %store/vec4 v0x245e540_0, 0, 1;
+    %store/vec4 v0x245e460_0, 0, 1;
+    %store/vec4 v0x245e870_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__24_.lut_data, S_0x245e260;
+    %store/vec4 v0x245eda0_0, 0, 1;
+T_32.2 ;
+T_32.1 ;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x245f130_0;
+    %load/vec4 v0x245f2b0_0;
+    %load/vec4 v0x245ebd0_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x245e6a0_0, 0, 1;
+    %store/vec4 v0x245e600_0, 0, 1;
+    %store/vec4 v0x245e540_0, 0, 1;
+    %store/vec4 v0x245e460_0, 0, 1;
+    %store/vec4 v0x245e870_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__24_.lut_data, S_0x245e260;
+    %store/vec4 v0x245ef20_0, 0, 1;
+    %jmp T_32;
+    .thread T_32, $push;
+    .scope S_0x245f910;
+T_33 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2461280_0, 0, 2;
+    %end;
+    .thread T_33;
+    .scope S_0x245f910;
+T_34 ;
+    %wait E_0x245e050;
+    %load/vec4 v0x2461280_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_34.0, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x2460d60_0;
+    %load/vec4 v0x2460ee0_0;
+    %load/vec4 v0x2461040_0;
+    %load/vec4 v0x24611c0_0;
+    %store/vec4 v0x2460310_0, 0, 1;
+    %store/vec4 v0x2460270_0, 0, 1;
+    %store/vec4 v0x24601b0_0, 0, 1;
+    %store/vec4 v0x24600d0_0, 0, 1;
+    %store/vec4 v0x24604e0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__25_.lut_data, S_0x245fed0;
+    %store/vec4 v0x24609f0_0, 0, 1;
+    %jmp T_34.1;
+T_34.0 ;
+    %load/vec4 v0x2461280_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_34.2, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x2460d60_0;
+    %load/vec4 v0x2460ee0_0;
+    %load/vec4 v0x2460840_0;
+    %load/vec4 v0x24611c0_0;
+    %store/vec4 v0x2460310_0, 0, 1;
+    %store/vec4 v0x2460270_0, 0, 1;
+    %store/vec4 v0x24601b0_0, 0, 1;
+    %store/vec4 v0x24600d0_0, 0, 1;
+    %store/vec4 v0x24604e0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__25_.lut_data, S_0x245fed0;
+    %store/vec4 v0x24609f0_0, 0, 1;
+T_34.2 ;
+T_34.1 ;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x2460d60_0;
+    %load/vec4 v0x2460ee0_0;
+    %load/vec4 v0x2460840_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2460310_0, 0, 1;
+    %store/vec4 v0x2460270_0, 0, 1;
+    %store/vec4 v0x24601b0_0, 0, 1;
+    %store/vec4 v0x24600d0_0, 0, 1;
+    %store/vec4 v0x24604e0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__25_.lut_data, S_0x245fed0;
+    %store/vec4 v0x2460b50_0, 0, 1;
+    %jmp T_34;
+    .thread T_34, $push;
+    .scope S_0x2461510;
+T_35 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2462ea0_0, 0, 2;
+    %end;
+    .thread T_35;
+    .scope S_0x2461510;
+T_36 ;
+    %wait E_0x245fcc0;
+    %load/vec4 v0x2462ea0_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_36.0, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x24629a0_0;
+    %load/vec4 v0x2462b20_0;
+    %load/vec4 v0x2462c80_0;
+    %load/vec4 v0x2462de0_0;
+    %store/vec4 v0x2461f10_0, 0, 1;
+    %store/vec4 v0x2461e70_0, 0, 1;
+    %store/vec4 v0x2461db0_0, 0, 1;
+    %store/vec4 v0x2461cd0_0, 0, 1;
+    %store/vec4 v0x24620e0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__26_.lut_data, S_0x2461ad0;
+    %store/vec4 v0x2462610_0, 0, 1;
+    %jmp T_36.1;
+T_36.0 ;
+    %load/vec4 v0x2462ea0_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_36.2, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x24629a0_0;
+    %load/vec4 v0x2462b20_0;
+    %load/vec4 v0x2462440_0;
+    %load/vec4 v0x2462de0_0;
+    %store/vec4 v0x2461f10_0, 0, 1;
+    %store/vec4 v0x2461e70_0, 0, 1;
+    %store/vec4 v0x2461db0_0, 0, 1;
+    %store/vec4 v0x2461cd0_0, 0, 1;
+    %store/vec4 v0x24620e0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__26_.lut_data, S_0x2461ad0;
+    %store/vec4 v0x2462610_0, 0, 1;
+T_36.2 ;
+T_36.1 ;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x24629a0_0;
+    %load/vec4 v0x2462b20_0;
+    %load/vec4 v0x2462440_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2461f10_0, 0, 1;
+    %store/vec4 v0x2461e70_0, 0, 1;
+    %store/vec4 v0x2461db0_0, 0, 1;
+    %store/vec4 v0x2461cd0_0, 0, 1;
+    %store/vec4 v0x24620e0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__26_.lut_data, S_0x2461ad0;
+    %store/vec4 v0x2462790_0, 0, 1;
+    %jmp T_36;
+    .thread T_36, $push;
+    .scope S_0x2463130;
+T_37 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2464ac0_0, 0, 2;
+    %end;
+    .thread T_37;
+    .scope S_0x2463130;
+T_38 ;
+    %wait E_0x24618c0;
+    %load/vec4 v0x2464ac0_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_38.0, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x24645a0_0;
+    %load/vec4 v0x2464720_0;
+    %load/vec4 v0x2464880_0;
+    %load/vec4 v0x2464a00_0;
+    %store/vec4 v0x2463b50_0, 0, 1;
+    %store/vec4 v0x2463ab0_0, 0, 1;
+    %store/vec4 v0x24639f0_0, 0, 1;
+    %store/vec4 v0x2463910_0, 0, 1;
+    %store/vec4 v0x2463d20_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__27_.lut_data, S_0x2463710;
+    %store/vec4 v0x2464230_0, 0, 1;
+    %jmp T_38.1;
+T_38.0 ;
+    %load/vec4 v0x2464ac0_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_38.2, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x24645a0_0;
+    %load/vec4 v0x2464720_0;
+    %load/vec4 v0x2464080_0;
+    %load/vec4 v0x2464a00_0;
+    %store/vec4 v0x2463b50_0, 0, 1;
+    %store/vec4 v0x2463ab0_0, 0, 1;
+    %store/vec4 v0x24639f0_0, 0, 1;
+    %store/vec4 v0x2463910_0, 0, 1;
+    %store/vec4 v0x2463d20_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__27_.lut_data, S_0x2463710;
+    %store/vec4 v0x2464230_0, 0, 1;
+T_38.2 ;
+T_38.1 ;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x24645a0_0;
+    %load/vec4 v0x2464720_0;
+    %load/vec4 v0x2464080_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2463b50_0, 0, 1;
+    %store/vec4 v0x2463ab0_0, 0, 1;
+    %store/vec4 v0x24639f0_0, 0, 1;
+    %store/vec4 v0x2463910_0, 0, 1;
+    %store/vec4 v0x2463d20_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__27_.lut_data, S_0x2463710;
+    %store/vec4 v0x2464390_0, 0, 1;
+    %jmp T_38;
+    .thread T_38, $push;
+    .scope S_0x2464d50;
+T_39 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2466810_0, 0, 2;
+    %end;
+    .thread T_39;
+    .scope S_0x2464d50;
+T_40 ;
+    %wait E_0x2463500;
+    %load/vec4 v0x2466810_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_40.0, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x24661f0_0;
+    %load/vec4 v0x2466370_0;
+    %load/vec4 v0x2466560_0;
+    %load/vec4 v0x2466750_0;
+    %store/vec4 v0x2465760_0, 0, 1;
+    %store/vec4 v0x24656c0_0, 0, 1;
+    %store/vec4 v0x2465600_0, 0, 1;
+    %store/vec4 v0x2465520_0, 0, 1;
+    %store/vec4 v0x2465930_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__28_.lut_data, S_0x2465320;
+    %store/vec4 v0x2465e60_0, 0, 1;
+    %jmp T_40.1;
+T_40.0 ;
+    %load/vec4 v0x2466810_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_40.2, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x24661f0_0;
+    %load/vec4 v0x2466370_0;
+    %load/vec4 v0x2465c90_0;
+    %load/vec4 v0x2466750_0;
+    %store/vec4 v0x2465760_0, 0, 1;
+    %store/vec4 v0x24656c0_0, 0, 1;
+    %store/vec4 v0x2465600_0, 0, 1;
+    %store/vec4 v0x2465520_0, 0, 1;
+    %store/vec4 v0x2465930_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__28_.lut_data, S_0x2465320;
+    %store/vec4 v0x2465e60_0, 0, 1;
+T_40.2 ;
+T_40.1 ;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x24661f0_0;
+    %load/vec4 v0x2466370_0;
+    %load/vec4 v0x2465c90_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2465760_0, 0, 1;
+    %store/vec4 v0x24656c0_0, 0, 1;
+    %store/vec4 v0x2465600_0, 0, 1;
+    %store/vec4 v0x2465520_0, 0, 1;
+    %store/vec4 v0x2465930_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__28_.lut_data, S_0x2465320;
+    %store/vec4 v0x2465fe0_0, 0, 1;
+    %jmp T_40;
+    .thread T_40, $push;
+    .scope S_0x2466aa0;
+T_41 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x24683e0_0, 0, 2;
+    %end;
+    .thread T_41;
+    .scope S_0x2466aa0;
+T_42 ;
+    %wait E_0x2465110;
+    %load/vec4 v0x24683e0_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_42.0, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x2467e30_0;
+    %load/vec4 v0x2467fb0_0;
+    %load/vec4 v0x24681a0_0;
+    %load/vec4 v0x2468320_0;
+    %store/vec4 v0x24673e0_0, 0, 1;
+    %store/vec4 v0x2467340_0, 0, 1;
+    %store/vec4 v0x2467280_0, 0, 1;
+    %store/vec4 v0x24671a0_0, 0, 1;
+    %store/vec4 v0x24675b0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__29_.lut_data, S_0x2466fa0;
+    %store/vec4 v0x2467ac0_0, 0, 1;
+    %jmp T_42.1;
+T_42.0 ;
+    %load/vec4 v0x24683e0_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_42.2, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x2467e30_0;
+    %load/vec4 v0x2467fb0_0;
+    %load/vec4 v0x2467910_0;
+    %load/vec4 v0x2468320_0;
+    %store/vec4 v0x24673e0_0, 0, 1;
+    %store/vec4 v0x2467340_0, 0, 1;
+    %store/vec4 v0x2467280_0, 0, 1;
+    %store/vec4 v0x24671a0_0, 0, 1;
+    %store/vec4 v0x24675b0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__29_.lut_data, S_0x2466fa0;
+    %store/vec4 v0x2467ac0_0, 0, 1;
+T_42.2 ;
+T_42.1 ;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x2467e30_0;
+    %load/vec4 v0x2467fb0_0;
+    %load/vec4 v0x2467910_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x24673e0_0, 0, 1;
+    %store/vec4 v0x2467340_0, 0, 1;
+    %store/vec4 v0x2467280_0, 0, 1;
+    %store/vec4 v0x24671a0_0, 0, 1;
+    %store/vec4 v0x24675b0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__29_.lut_data, S_0x2466fa0;
+    %store/vec4 v0x2467c20_0, 0, 1;
+    %jmp T_42;
+    .thread T_42, $push;
+    .scope S_0x2468670;
+T_43 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2469fc0_0, 0, 2;
+    %end;
+    .thread T_43;
+    .scope S_0x2468670;
+T_44 ;
+    %wait E_0x2466d90;
+    %load/vec4 v0x2469fc0_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_44.0, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x2469ac0_0;
+    %load/vec4 v0x2469c40_0;
+    %load/vec4 v0x2469da0_0;
+    %load/vec4 v0x2469f00_0;
+    %store/vec4 v0x2469030_0, 0, 1;
+    %store/vec4 v0x2468f90_0, 0, 1;
+    %store/vec4 v0x2468ed0_0, 0, 1;
+    %store/vec4 v0x2468df0_0, 0, 1;
+    %store/vec4 v0x2469200_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__30_.lut_data, S_0x2468bf0;
+    %store/vec4 v0x2469730_0, 0, 1;
+    %jmp T_44.1;
+T_44.0 ;
+    %load/vec4 v0x2469fc0_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_44.2, 4;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x2469ac0_0;
+    %load/vec4 v0x2469c40_0;
+    %load/vec4 v0x2469560_0;
+    %load/vec4 v0x2469f00_0;
+    %store/vec4 v0x2469030_0, 0, 1;
+    %store/vec4 v0x2468f90_0, 0, 1;
+    %store/vec4 v0x2468ed0_0, 0, 1;
+    %store/vec4 v0x2468df0_0, 0, 1;
+    %store/vec4 v0x2469200_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__30_.lut_data, S_0x2468bf0;
+    %store/vec4 v0x2469730_0, 0, 1;
+T_44.2 ;
+T_44.1 ;
+    %pushi/vec4 778, 0, 16;
+    %load/vec4 v0x2469ac0_0;
+    %load/vec4 v0x2469c40_0;
+    %load/vec4 v0x2469560_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2469030_0, 0, 1;
+    %store/vec4 v0x2468f90_0, 0, 1;
+    %store/vec4 v0x2468ed0_0, 0, 1;
+    %store/vec4 v0x2468df0_0, 0, 1;
+    %store/vec4 v0x2469200_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__30_.lut_data, S_0x2468bf0;
+    %store/vec4 v0x24698b0_0, 0, 1;
+    %jmp T_44;
+    .thread T_44, $push;
+    .scope S_0x246a250;
+T_45 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x246bba0_0, 0, 2;
+    %end;
+    .thread T_45;
+    .scope S_0x246a250;
+T_46 ;
+    %wait E_0x24689e0;
+    %load/vec4 v0x246bba0_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_46.0, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x246b680_0;
+    %load/vec4 v0x246b800_0;
+    %load/vec4 v0x246b960_0;
+    %load/vec4 v0x246bae0_0;
+    %store/vec4 v0x246ac30_0, 0, 1;
+    %store/vec4 v0x246ab90_0, 0, 1;
+    %store/vec4 v0x246aad0_0, 0, 1;
+    %store/vec4 v0x246a9f0_0, 0, 1;
+    %store/vec4 v0x246ae00_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__31_.lut_data, S_0x246a7f0;
+    %store/vec4 v0x246b310_0, 0, 1;
+    %jmp T_46.1;
+T_46.0 ;
+    %load/vec4 v0x246bba0_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_46.2, 4;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x246b680_0;
+    %load/vec4 v0x246b800_0;
+    %load/vec4 v0x246b160_0;
+    %load/vec4 v0x246bae0_0;
+    %store/vec4 v0x246ac30_0, 0, 1;
+    %store/vec4 v0x246ab90_0, 0, 1;
+    %store/vec4 v0x246aad0_0, 0, 1;
+    %store/vec4 v0x246a9f0_0, 0, 1;
+    %store/vec4 v0x246ae00_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__31_.lut_data, S_0x246a7f0;
+    %store/vec4 v0x246b310_0, 0, 1;
+T_46.2 ;
+T_46.1 ;
+    %pushi/vec4 21331, 0, 16;
+    %load/vec4 v0x246b680_0;
+    %load/vec4 v0x246b800_0;
+    %load/vec4 v0x246b160_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x246ac30_0, 0, 1;
+    %store/vec4 v0x246ab90_0, 0, 1;
+    %store/vec4 v0x246aad0_0, 0, 1;
+    %store/vec4 v0x246a9f0_0, 0, 1;
+    %store/vec4 v0x246ae00_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__31_.lut_data, S_0x246a7f0;
+    %store/vec4 v0x246b470_0, 0, 1;
+    %jmp T_46;
+    .thread T_46, $push;
+    .scope S_0x246be30;
+T_47 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x246d810_0, 0, 2;
+    %end;
+    .thread T_47;
+    .scope S_0x246be30;
+T_48 ;
+    %wait E_0x246a5e0;
+    %load/vec4 v0x246d810_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_48.0, 4;
+    %pushi/vec4 38505, 0, 16;
+    %load/vec4 v0x246d2d0_0;
+    %load/vec4 v0x246d450_0;
+    %load/vec4 v0x246d5d0_0;
+    %load/vec4 v0x246d750_0;
+    %store/vec4 v0x246c840_0, 0, 1;
+    %store/vec4 v0x246c7a0_0, 0, 1;
+    %store/vec4 v0x246c6e0_0, 0, 1;
+    %store/vec4 v0x246c600_0, 0, 1;
+    %store/vec4 v0x246ca10_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__32_.lut_data, S_0x246c400;
+    %store/vec4 v0x246cf40_0, 0, 1;
+    %jmp T_48.1;
+T_48.0 ;
+    %load/vec4 v0x246d810_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_48.2, 4;
+    %pushi/vec4 38505, 0, 16;
+    %load/vec4 v0x246d2d0_0;
+    %load/vec4 v0x246d450_0;
+    %load/vec4 v0x246cd70_0;
+    %load/vec4 v0x246d750_0;
+    %store/vec4 v0x246c840_0, 0, 1;
+    %store/vec4 v0x246c7a0_0, 0, 1;
+    %store/vec4 v0x246c6e0_0, 0, 1;
+    %store/vec4 v0x246c600_0, 0, 1;
+    %store/vec4 v0x246ca10_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__32_.lut_data, S_0x246c400;
+    %store/vec4 v0x246cf40_0, 0, 1;
+T_48.2 ;
+T_48.1 ;
+    %pushi/vec4 38505, 0, 16;
+    %load/vec4 v0x246d2d0_0;
+    %load/vec4 v0x246d450_0;
+    %load/vec4 v0x246cd70_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x246c840_0, 0, 1;
+    %store/vec4 v0x246c7a0_0, 0, 1;
+    %store/vec4 v0x246c6e0_0, 0, 1;
+    %store/vec4 v0x246c600_0, 0, 1;
+    %store/vec4 v0x246ca10_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__32_.lut_data, S_0x246c400;
+    %store/vec4 v0x246d0c0_0, 0, 1;
+    %jmp T_48;
+    .thread T_48, $push;
+    .scope S_0x246daa0;
+T_49 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x246f430_0, 0, 2;
+    %end;
+    .thread T_49;
+    .scope S_0x246daa0;
+T_50 ;
+    %wait E_0x246c1f0;
+    %load/vec4 v0x246f430_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_50.0, 4;
+    %pushi/vec4 320, 0, 16;
+    %load/vec4 v0x246ef10_0;
+    %load/vec4 v0x246f090_0;
+    %load/vec4 v0x246f1f0_0;
+    %load/vec4 v0x246f370_0;
+    %store/vec4 v0x246e480_0, 0, 1;
+    %store/vec4 v0x246e3e0_0, 0, 1;
+    %store/vec4 v0x246e320_0, 0, 1;
+    %store/vec4 v0x246e240_0, 0, 1;
+    %store/vec4 v0x246e650_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__33_.lut_data, S_0x246e040;
+    %store/vec4 v0x246eb80_0, 0, 1;
+    %jmp T_50.1;
+T_50.0 ;
+    %load/vec4 v0x246f430_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_50.2, 4;
+    %pushi/vec4 320, 0, 16;
+    %load/vec4 v0x246ef10_0;
+    %load/vec4 v0x246f090_0;
+    %load/vec4 v0x246e9b0_0;
+    %load/vec4 v0x246f370_0;
+    %store/vec4 v0x246e480_0, 0, 1;
+    %store/vec4 v0x246e3e0_0, 0, 1;
+    %store/vec4 v0x246e320_0, 0, 1;
+    %store/vec4 v0x246e240_0, 0, 1;
+    %store/vec4 v0x246e650_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__33_.lut_data, S_0x246e040;
+    %store/vec4 v0x246eb80_0, 0, 1;
+T_50.2 ;
+T_50.1 ;
+    %pushi/vec4 320, 0, 16;
+    %load/vec4 v0x246ef10_0;
+    %load/vec4 v0x246f090_0;
+    %load/vec4 v0x246e9b0_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x246e480_0, 0, 1;
+    %store/vec4 v0x246e3e0_0, 0, 1;
+    %store/vec4 v0x246e320_0, 0, 1;
+    %store/vec4 v0x246e240_0, 0, 1;
+    %store/vec4 v0x246e650_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__33_.lut_data, S_0x246e040;
+    %store/vec4 v0x246ed00_0, 0, 1;
+    %jmp T_50;
+    .thread T_50, $push;
+    .scope S_0x246f6c0;
+T_51 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2471040_0, 0, 2;
+    %end;
+    .thread T_51;
+    .scope S_0x246f6c0;
+T_52 ;
+    %wait E_0x246de30;
+    %load/vec4 v0x2471040_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_52.0, 4;
+    %pushi/vec4 4096, 0, 16;
+    %load/vec4 v0x2470b30_0;
+    %load/vec4 v0x2470cb0_0;
+    %load/vec4 v0x2470e10_0;
+    %load/vec4 v0x2470f80_0;
+    %store/vec4 v0x24700a0_0, 0, 1;
+    %store/vec4 v0x2470000_0, 0, 1;
+    %store/vec4 v0x246ff40_0, 0, 1;
+    %store/vec4 v0x246fe60_0, 0, 1;
+    %store/vec4 v0x2470270_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__34_.lut_data, S_0x246fc60;
+    %store/vec4 v0x24707a0_0, 0, 1;
+    %jmp T_52.1;
+T_52.0 ;
+    %load/vec4 v0x2471040_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_52.2, 4;
+    %pushi/vec4 4096, 0, 16;
+    %load/vec4 v0x2470b30_0;
+    %load/vec4 v0x2470cb0_0;
+    %load/vec4 v0x24705d0_0;
+    %load/vec4 v0x2470f80_0;
+    %store/vec4 v0x24700a0_0, 0, 1;
+    %store/vec4 v0x2470000_0, 0, 1;
+    %store/vec4 v0x246ff40_0, 0, 1;
+    %store/vec4 v0x246fe60_0, 0, 1;
+    %store/vec4 v0x2470270_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__34_.lut_data, S_0x246fc60;
+    %store/vec4 v0x24707a0_0, 0, 1;
+T_52.2 ;
+T_52.1 ;
+    %pushi/vec4 4096, 0, 16;
+    %load/vec4 v0x2470b30_0;
+    %load/vec4 v0x2470cb0_0;
+    %load/vec4 v0x24705d0_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x24700a0_0, 0, 1;
+    %store/vec4 v0x2470000_0, 0, 1;
+    %store/vec4 v0x246ff40_0, 0, 1;
+    %store/vec4 v0x246fe60_0, 0, 1;
+    %store/vec4 v0x2470270_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__34_.lut_data, S_0x246fc60;
+    %store/vec4 v0x2470920_0, 0, 1;
+    %jmp T_52;
+    .thread T_52, $push;
+    .scope S_0x24712d0;
+T_53 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2472cc0_0, 0, 2;
+    %end;
+    .thread T_53;
+    .scope S_0x24712d0;
+T_54 ;
+    %wait E_0x2463310;
+    %load/vec4 v0x2472cc0_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_54.0, 4;
+    %pushi/vec4 28784, 0, 16;
+    %load/vec4 v0x24727a0_0;
+    %load/vec4 v0x2472900_0;
+    %load/vec4 v0x2472a80_0;
+    %load/vec4 v0x2472c00_0;
+    %store/vec4 v0x2471d30_0, 0, 1;
+    %store/vec4 v0x2471c90_0, 0, 1;
+    %store/vec4 v0x2471bd0_0, 0, 1;
+    %store/vec4 v0x2471af0_0, 0, 1;
+    %store/vec4 v0x2471f00_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__35_.lut_data, S_0x24718f0;
+    %store/vec4 v0x2472430_0, 0, 1;
+    %jmp T_54.1;
+T_54.0 ;
+    %load/vec4 v0x2472cc0_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_54.2, 4;
+    %pushi/vec4 28784, 0, 16;
+    %load/vec4 v0x24727a0_0;
+    %load/vec4 v0x2472900_0;
+    %load/vec4 v0x2472260_0;
+    %load/vec4 v0x2472c00_0;
+    %store/vec4 v0x2471d30_0, 0, 1;
+    %store/vec4 v0x2471c90_0, 0, 1;
+    %store/vec4 v0x2471bd0_0, 0, 1;
+    %store/vec4 v0x2471af0_0, 0, 1;
+    %store/vec4 v0x2471f00_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__35_.lut_data, S_0x24718f0;
+    %store/vec4 v0x2472430_0, 0, 1;
+T_54.2 ;
+T_54.1 ;
+    %pushi/vec4 28784, 0, 16;
+    %load/vec4 v0x24727a0_0;
+    %load/vec4 v0x2472900_0;
+    %load/vec4 v0x2472260_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2471d30_0, 0, 1;
+    %store/vec4 v0x2471c90_0, 0, 1;
+    %store/vec4 v0x2471bd0_0, 0, 1;
+    %store/vec4 v0x2471af0_0, 0, 1;
+    %store/vec4 v0x2471f00_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__35_.lut_data, S_0x24718f0;
+    %store/vec4 v0x24725b0_0, 0, 1;
+    %jmp T_54;
+    .thread T_54, $push;
+    .scope S_0x2472f50;
+T_55 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x24749d0_0, 0, 2;
+    %end;
+    .thread T_55;
+    .scope S_0x2472f50;
+T_56 ;
+    %wait E_0x246fa50;
+    %load/vec4 v0x24749d0_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_56.0, 4;
+    %pushi/vec4 43715, 0, 16;
+    %load/vec4 v0x24743c0_0;
+    %load/vec4 v0x2474540_0;
+    %load/vec4 v0x24746c0_0;
+    %load/vec4 v0x2474930_0;
+    %store/vec4 v0x2473930_0, 0, 1;
+    %store/vec4 v0x2473890_0, 0, 1;
+    %store/vec4 v0x24737d0_0, 0, 1;
+    %store/vec4 v0x24736f0_0, 0, 1;
+    %store/vec4 v0x2473b00_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__36_.lut_data, S_0x24734f0;
+    %store/vec4 v0x2474030_0, 0, 1;
+    %jmp T_56.1;
+T_56.0 ;
+    %load/vec4 v0x24749d0_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_56.2, 4;
+    %pushi/vec4 43715, 0, 16;
+    %load/vec4 v0x24743c0_0;
+    %load/vec4 v0x2474540_0;
+    %load/vec4 v0x2473e60_0;
+    %load/vec4 v0x2474930_0;
+    %store/vec4 v0x2473930_0, 0, 1;
+    %store/vec4 v0x2473890_0, 0, 1;
+    %store/vec4 v0x24737d0_0, 0, 1;
+    %store/vec4 v0x24736f0_0, 0, 1;
+    %store/vec4 v0x2473b00_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__36_.lut_data, S_0x24734f0;
+    %store/vec4 v0x2474030_0, 0, 1;
+T_56.2 ;
+T_56.1 ;
+    %pushi/vec4 43715, 0, 16;
+    %load/vec4 v0x24743c0_0;
+    %load/vec4 v0x2474540_0;
+    %load/vec4 v0x2473e60_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2473930_0, 0, 1;
+    %store/vec4 v0x2473890_0, 0, 1;
+    %store/vec4 v0x24737d0_0, 0, 1;
+    %store/vec4 v0x24736f0_0, 0, 1;
+    %store/vec4 v0x2473b00_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__36_.lut_data, S_0x24734f0;
+    %store/vec4 v0x24741b0_0, 0, 1;
+    %jmp T_56;
+    .thread T_56, $push;
+    .scope S_0x2474c00;
+T_57 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2476520_0, 0, 2;
+    %end;
+    .thread T_57;
+    .scope S_0x2474c00;
+T_58 ;
+    %wait E_0x24732e0;
+    %load/vec4 v0x2476520_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_58.0, 4;
+    %pushi/vec4 1800, 0, 16;
+    %load/vec4 v0x2476050_0;
+    %load/vec4 v0x2476190_0;
+    %load/vec4 v0x24762f0_0;
+    %load/vec4 v0x2476480_0;
+    %store/vec4 v0x24755e0_0, 0, 1;
+    %store/vec4 v0x2475540_0, 0, 1;
+    %store/vec4 v0x2475480_0, 0, 1;
+    %store/vec4 v0x24753a0_0, 0, 1;
+    %store/vec4 v0x24757b0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__37_.lut_data, S_0x24751a0;
+    %store/vec4 v0x2475ce0_0, 0, 1;
+    %jmp T_58.1;
+T_58.0 ;
+    %load/vec4 v0x2476520_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_58.2, 4;
+    %pushi/vec4 1800, 0, 16;
+    %load/vec4 v0x2476050_0;
+    %load/vec4 v0x2476190_0;
+    %load/vec4 v0x2475b10_0;
+    %load/vec4 v0x2476480_0;
+    %store/vec4 v0x24755e0_0, 0, 1;
+    %store/vec4 v0x2475540_0, 0, 1;
+    %store/vec4 v0x2475480_0, 0, 1;
+    %store/vec4 v0x24753a0_0, 0, 1;
+    %store/vec4 v0x24757b0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__37_.lut_data, S_0x24751a0;
+    %store/vec4 v0x2475ce0_0, 0, 1;
+T_58.2 ;
+T_58.1 ;
+    %pushi/vec4 1800, 0, 16;
+    %load/vec4 v0x2476050_0;
+    %load/vec4 v0x2476190_0;
+    %load/vec4 v0x2475b10_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x24755e0_0, 0, 1;
+    %store/vec4 v0x2475540_0, 0, 1;
+    %store/vec4 v0x2475480_0, 0, 1;
+    %store/vec4 v0x24753a0_0, 0, 1;
+    %store/vec4 v0x24757b0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__37_.lut_data, S_0x24751a0;
+    %store/vec4 v0x2475e60_0, 0, 1;
+    %jmp T_58;
+    .thread T_58, $push;
+    .scope S_0x24767b0;
+T_59 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2478220_0, 0, 2;
+    %end;
+    .thread T_59;
+    .scope S_0x24767b0;
+T_60 ;
+    %wait E_0x2474f90;
+    %load/vec4 v0x2478220_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_60.0, 4;
+    %pushi/vec4 2572, 0, 16;
+    %load/vec4 v0x2477c30_0;
+    %load/vec4 v0x2477db0_0;
+    %load/vec4 v0x2477f10_0;
+    %load/vec4 v0x2478180_0;
+    %store/vec4 v0x24771c0_0, 0, 1;
+    %store/vec4 v0x2477120_0, 0, 1;
+    %store/vec4 v0x2477060_0, 0, 1;
+    %store/vec4 v0x2476f80_0, 0, 1;
+    %store/vec4 v0x2477390_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__38_.lut_data, S_0x2476d80;
+    %store/vec4 v0x24778c0_0, 0, 1;
+    %jmp T_60.1;
+T_60.0 ;
+    %load/vec4 v0x2478220_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_60.2, 4;
+    %pushi/vec4 2572, 0, 16;
+    %load/vec4 v0x2477c30_0;
+    %load/vec4 v0x2477db0_0;
+    %load/vec4 v0x24776f0_0;
+    %load/vec4 v0x2478180_0;
+    %store/vec4 v0x24771c0_0, 0, 1;
+    %store/vec4 v0x2477120_0, 0, 1;
+    %store/vec4 v0x2477060_0, 0, 1;
+    %store/vec4 v0x2476f80_0, 0, 1;
+    %store/vec4 v0x2477390_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__38_.lut_data, S_0x2476d80;
+    %store/vec4 v0x24778c0_0, 0, 1;
+T_60.2 ;
+T_60.1 ;
+    %pushi/vec4 2572, 0, 16;
+    %load/vec4 v0x2477c30_0;
+    %load/vec4 v0x2477db0_0;
+    %load/vec4 v0x24776f0_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x24771c0_0, 0, 1;
+    %store/vec4 v0x2477120_0, 0, 1;
+    %store/vec4 v0x2477060_0, 0, 1;
+    %store/vec4 v0x2476f80_0, 0, 1;
+    %store/vec4 v0x2477390_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__38_.lut_data, S_0x2476d80;
+    %store/vec4 v0x2477a40_0, 0, 1;
+    %jmp T_60;
+    .thread T_60, $push;
+    .scope S_0x24783d0;
+T_61 ;
+    %pushi/vec4 0, 0, 2;
+    %store/vec4 v0x2479d40_0, 0, 2;
+    %end;
+    .thread T_61;
+    .scope S_0x24783d0;
+T_62 ;
+    %wait E_0x2476b70;
+    %load/vec4 v0x2479d40_0;
+    %pad/u 32;
+    %cmpi/e 0, 0, 32;
+    %jmp/0xz  T_62.0, 4;
+    %pushi/vec4 45232, 0, 16;
+    %load/vec4 v0x2479850_0;
+    %load/vec4 v0x2479990_0;
+    %load/vec4 v0x2479b20_0;
+    %load/vec4 v0x2479c80_0;
+    %store/vec4 v0x2478de0_0, 0, 1;
+    %store/vec4 v0x2478d40_0, 0, 1;
+    %store/vec4 v0x2478c80_0, 0, 1;
+    %store/vec4 v0x2478ba0_0, 0, 1;
+    %store/vec4 v0x2478fb0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__39_.lut_data, S_0x24789a0;
+    %store/vec4 v0x24794e0_0, 0, 1;
+    %jmp T_62.1;
+T_62.0 ;
+    %load/vec4 v0x2479d40_0;
+    %pad/u 32;
+    %cmpi/e 1, 0, 32;
+    %jmp/0xz  T_62.2, 4;
+    %pushi/vec4 45232, 0, 16;
+    %load/vec4 v0x2479850_0;
+    %load/vec4 v0x2479990_0;
+    %load/vec4 v0x2479310_0;
+    %load/vec4 v0x2479c80_0;
+    %store/vec4 v0x2478de0_0, 0, 1;
+    %store/vec4 v0x2478d40_0, 0, 1;
+    %store/vec4 v0x2478c80_0, 0, 1;
+    %store/vec4 v0x2478ba0_0, 0, 1;
+    %store/vec4 v0x2478fb0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__39_.lut_data, S_0x24789a0;
+    %store/vec4 v0x24794e0_0, 0, 1;
+T_62.2 ;
+T_62.1 ;
+    %pushi/vec4 45232, 0, 16;
+    %load/vec4 v0x2479850_0;
+    %load/vec4 v0x2479990_0;
+    %load/vec4 v0x2479310_0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2478de0_0, 0, 1;
+    %store/vec4 v0x2478d40_0, 0, 1;
+    %store/vec4 v0x2478c80_0, 0, 1;
+    %store/vec4 v0x2478ba0_0, 0, 1;
+    %store/vec4 v0x2478fb0_0, 0, 16;
+    %callf/vec4 TD_tb.U.yosys__39_.lut_data, S_0x24789a0;
+    %store/vec4 v0x2479660_0, 0, 1;
+    %jmp T_62;
+    .thread T_62, $push;
+    .scope S_0x247e350;
+T_63 ;
+    %wait E_0x2478790;
+    %load/vec4 v0x247eb60_0;
+    %assign/vec4 v0x247edd0_0, 0;
+    %jmp T_63;
+    .thread T_63;
+    .scope S_0x247f240;
+T_64 ;
+    %wait E_0x2478790;
+    %load/vec4 v0x247f9a0_0;
+    %assign/vec4 v0x247fc30_0, 0;
+    %jmp T_64;
+    .thread T_64;
+    .scope S_0x24800a0;
+T_65 ;
+    %wait E_0x2478790;
+    %load/vec4 v0x2480780_0;
+    %assign/vec4 v0x2480a10_0, 0;
+    %jmp T_65;
+    .thread T_65;
+    .scope S_0x2480e80;
+T_66 ;
+    %wait E_0x2478790;
+    %load/vec4 v0x24815f0_0;
+    %assign/vec4 v0x2481830_0, 0;
+    %jmp T_66;
+    .thread T_66;
+    .scope S_0x2481ca0;
+T_67 ;
+    %wait E_0x2478790;
+    %load/vec4 v0x2482380_0;
+    %assign/vec4 v0x2482610_0, 0;
+    %jmp T_67;
+    .thread T_67;
+    .scope S_0x2482a80;
+T_68 ;
+    %wait E_0x2478790;
+    %load/vec4 v0x2483160_0;
+    %assign/vec4 v0x24833f0_0, 0;
+    %jmp T_68;
+    .thread T_68;
+    .scope S_0x2483860;
+T_69 ;
+    %wait E_0x2478790;
+    %load/vec4 v0x2483f40_0;
+    %assign/vec4 v0x24841d0_0, 0;
+    %jmp T_69;
+    .thread T_69;
+    .scope S_0x2484640;
+T_70 ;
+    %wait E_0x2478790;
+    %load/vec4 v0x2484e30_0;
+    %assign/vec4 v0x2485030_0, 0;
+    %jmp T_70;
+    .thread T_70;
+    .scope S_0x24219d0;
+T_71 ;
+    %vpi_call 2 11 "$monitor", "rst %b en %b updown %b cnt %b overflow %b", v0x2487ab0_0, v0x24878d0_0, v0x2487bf0_0, v0x2487810_0, v0x24879c0_0 {0 0 0};
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2487700_0, 0, 1;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x2487ab0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x24878d0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2487bf0_0, 0, 1;
+    %delay 10, 0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v0x2487ab0_0, 0, 1;
+    %delay 1, 0;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x24878d0_0, 0, 1;
+    %delay 20, 0;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v0x2487bf0_0, 0, 1;
+    %delay 30, 0;
+    %vpi_call 2 20 "$finish" {0 0 0};
+    %end;
+    .thread T_71;
+    .scope S_0x24219d0;
+T_72 ;
+    %delay 1, 0;
+    %load/vec4 v0x2487700_0;
+    %inv;
+    %store/vec4 v0x2487700_0, 0, 1;
+    %jmp T_72;
+    .thread T_72;
+# The file index is used to find the file name in the following table.
+:file_names 5;
+    "N/A";
+    "<interactive>";
+    "lfsr_updown_tb.v";
+    "top.vqm";
+    "/usr/local/share/yosys/altera_intel/max10/cells_comb_max10.v";

--- a/techlibs/altera_intel/Makefile.inc
+++ b/techlibs/altera_intel/Makefile.inc
@@ -1,0 +1,10 @@
+
+OBJS += techlibs/altera_intel/synth_intel.o
+
+#$(eval $(call add_share_file,share/altera_intel,techlibs/altera_intel/lpm_functions.v))
+$(eval $(call add_share_file,share/altera_intel/max10,techlibs/altera_intel/max10/cells_comb_max10.v))
+$(eval $(call add_share_file,share/altera_intel/cycloneiv,techlibs/altera_intel/cycloneiv/cells_comb_cycloneiv.v))
+$(eval $(call add_share_file,share/altera_intel/max10,techlibs/altera_intel/max10/cells_map_max10.v))
+$(eval $(call add_share_file,share/altera_intel/cycloneiv,techlibs/altera_intel/cycloneiv/cells_map_cycloneiv.v))
+#$(eval $(call add_share_file,share/altera_intel/max10,techlibs/altera_intel/max10/cells_arith_max10.v))
+

--- a/techlibs/altera_intel/cycloneiv/cells_comb_cycloneiv.v
+++ b/techlibs/altera_intel/cycloneiv/cells_comb_cycloneiv.v
@@ -1,0 +1,111 @@
+module VCC (output V);
+   assign V = 1'b1;
+endmodule // VCC
+
+module GND (output G);
+   assign G = 1'b0;
+endmodule // GND
+
+/* Altera Cyclone IV (GX) devices Input Buffer Primitive */
+module cycloneiv_io_ibuf (output o, input i, input ibar);
+   assign ibar = ibar;
+   assign o    = i;
+endmodule // fiftyfivenm_io_ibuf
+
+/* Altera Cyclone IV (GX)  devices Output Buffer Primitive */
+module cycloneiv_io_obuf (output o, input i, input oe);
+   assign o  = i;
+   assign oe = oe;
+endmodule // fiftyfivenm_io_obuf
+
+/* Altera MAX10 4-input non-fracturable LUT Primitive */ 
+module cycloneiv_lcell_comb (output combout, cout,
+                             input dataa, datab, datac, datad, cin);
+
+/* Internal parameters which define the behaviour
+   of the LUT primitive.
+   lut_mask define the lut function, can be expressed in 16-digit bin or hex.
+   sum_lutc_input define the type of LUT (combinational | arithmetic). 
+   dont_touch for retiming || carry options.
+   lpm_type for WYSIWYG */  
+   
+parameter lut_mask = 16'hFFFF;
+parameter sum_lutc_input = "datac";
+parameter dont_touch = "off";
+parameter lpm_type = "fiftyfivenm_lcell_comb";
+  
+reg [1:0] lut_type;  
+reg cout_rt;
+reg combout_rt;
+
+wire dataa_w;
+wire datab_w;
+wire datac_w;
+wire datad_w;
+wire cin_w;
+
+assign dataa_w = dataa;
+assign datab_w = datab;
+assign datac_w = datac;
+assign datad_w = datad;
+
+function lut_data;
+input [15:0] mask;
+input dataa;
+input datab;
+input datac;
+input datad;
+
+  begin
+    lut_data = datad ? (datac ? (datab ? (dataa ? mask[15] : mask[14]) : (dataa ?  mask[13] : mask[12])) 
+                     : (datab ? (dataa ? mask[11] : mask[10]) : (dataa ?  mask[ 9] : mask[ 8])))
+                     : (datac ? (datab ? ( dataa ? mask[7] : mask[6]) : (dataa ?  mask[5] : mask[4])) 
+                     : (datab ? (dataa ? mask[3] : mask[2]) : ( dataa ? mask[1] : mask[0])));
+  end
+
+endfunction
+
+initial begin
+    if (sum_lutc_input == "datac") lut_type = 0;
+    else 
+    if (sum_lutc_input == "cin")   lut_type = 1;
+    else                           lut_type = 2;
+end
+
+always @(dataa_w or datab_w or datac_w or datad_w or cin_w) begin
+    if (lut_type == 0) begin
+        combout_rt = lut_data(lut_mask, dataa_w, datab_w, 
+                            datac_w, datad_w);
+    end
+    else if (lut_type == 1) begin
+        combout_rt = lut_data(lut_mask, dataa_w, datab_w, 
+                            cin_w, datad_w);
+    end
+    cout_rt = lut_data(lut_mask, dataa_w, datab_w, cin_w, 'b0);
+end
+
+assign combout = combout_rt & 1'b1;
+assign cout = cout_rt & 1'b1;
+
+endmodule // cycloneiv_lcell_comb
+
+// DFF
+module dffeas #(parameter power_up="dontcare", is_wysiwyg="false") ( output q, 
+								     input d, 
+								     input clk, 
+								     input clrn, 
+								     input prn, 
+								     input ena, 
+								     input asdata, 
+								     input aload, 
+								     input sclr, 
+  								     input sload );
+  reg q;
+
+  always @(posedge clk)
+    q <= d;
+   
+endmodule
+
+
+

--- a/techlibs/altera_intel/cycloneiv/cells_map_cycloneiv.v
+++ b/techlibs/altera_intel/cycloneiv/cells_map_cycloneiv.v
@@ -1,0 +1,43 @@
+// Flip-flop D
+module  \$_DFF_P_ (input D, input C, output Q);
+   parameter WYSIWYG="TRUE";
+   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+endmodule //
+
+// Input buffer map
+module \$__inpad (input I, output O);
+    cycloneiv_io_ibuf _TECHMAP_REPLACE_ (.o(O), .i(I), .ibar(1'b0));
+endmodule 
+
+// Output buffer map   
+module \$__outpad (input I, output O);
+    cycloneiv_io_obuf _TECHMAP_REPLACE_ (.o(O), .i(I), .oe(1'b1));
+endmodule 
+
+// LUT Map
+/* 0 -> datac
+   1 -> cin */
+module \$lut (A, Y);
+   parameter WIDTH  = 0;
+   parameter LUT    = 0;
+   parameter SPLIT4 = {LUT[15:12], LUT[7:4], LUT[11:8], LUT[3:0]}; // used for 4-in luts, KISS;
+   input [WIDTH-1:0] A;
+   output 	     Y;
+   generate 
+      if (WIDTH == 1) begin
+	   assign Y = ~A[0]; // Not need to spend 1 logic cell for such an easy function
+      end else
+      if (WIDTH == 2) begin
+           cycloneiv_lcell_comb #(.lut_mask({4{LUT}}), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(1'b1),.datad(1'b1));
+      end else
+      if(WIDTH == 3) begin 
+	   cycloneiv_lcell_comb #(.lut_mask({2{LUT}}), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(A[2]),.datad(1'b1));
+      end else
+      if(WIDTH == 4) begin
+	   cycloneiv_lcell_comb #(.lut_mask(LUT), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(A[2]),.datad(A[3]));
+      end else
+	   wire _TECHMAP_FAIL_ = 1;
+   endgenerate
+endmodule //
+
+	    

--- a/techlibs/altera_intel/lpm_functions.v
+++ b/techlibs/altera_intel/lpm_functions.v
@@ -1,0 +1,299 @@
+(* techmap_celltype = "$altpll" *)
+module _80_altpll_altera  ( input [1:0] inclk, 
+			    input       fbin, 
+			    input       pllena, 
+			    input       clkswitch, 
+			    input       areset, 
+			    input       pfdena, 
+			    input       clkena, 
+			    input       extclkena, 
+			    input       scanclk, 
+			    input 	scanaclr, 
+			    input       scanclkena, 
+			    input       scanread, 
+			    input       scanwrite, 
+			    input       scandata, 
+			    input       phasecounterselect, 
+			    input       phaseupdown,
+			    input       phasestep,
+			    input       configupdate,
+			    inout       fbmimicbidir,
+			    
+			    output [width_clock-1:0] clk, 
+			    output [3:0]             extclk,     
+			    output [1:0]             clkbad,     
+			    output 	             enable0,     
+			    output 		     enable1,     
+			    output 		     activeclock, 
+			    output 		     clkloss,     
+			    output 		     locked,      
+			    output 		     scandataout, 
+			    output 		     scandone,    
+			    output 		     sclkout0,    
+			    output 		     sclkout1,    
+			    output 	             phasedone,
+			    output 		     vcooverrange,
+			    output 		     vcounderrange,
+			    output 		     fbout,
+			    output 		     fref,
+			    output 		     icdrclk );
+			    
+			    parameter   intended_device_family    = "MAX 10";
+			    parameter   operation_mode            = "NORMAL";
+			    parameter   pll_type                  = "AUTO";
+			    parameter   qualify_conf_done         = "OFF";
+			    parameter   compensate_clock          = "CLK0";
+			    parameter   scan_chain                = "LONG";
+			    parameter   primary_clock             = "inclk0";
+			    parameter   inclk0_input_frequency    = 1000;
+			    parameter   inclk1_input_frequency    = 0;
+			    parameter   gate_lock_signal          = "NO";
+			    parameter   gate_lock_counter         = 0;
+			    parameter   lock_high                 = 1;
+			    parameter   lock_low                  = 0;
+			    parameter   valid_lock_multiplier     = 1;
+			    parameter   invalid_lock_multiplier   = 5;
+			    parameter   switch_over_type          = "AUTO";
+			    parameter   switch_over_on_lossclk    = "OFF" ;
+			    parameter   switch_over_on_gated_lock = "OFF" ;
+			    parameter   enable_switch_over_counter = "OFF";
+			    parameter   switch_over_counter       = 0;
+			    parameter   feedback_source           = "EXTCLK0" ;
+			    parameter   bandwidth                 = 0;
+			    parameter   bandwidth_type            = "UNUSED";
+			    parameter   lpm_hint                  = "UNUSED";
+			    parameter   spread_frequency          = 0;
+			    parameter   down_spread               = "0.0";
+			    parameter   self_reset_on_gated_loss_lock = "OFF";
+			    parameter   self_reset_on_loss_lock = "OFF";
+			    parameter   lock_window_ui           = "0.05";
+			    parameter   width_clock              = 6;
+			    parameter   width_phasecounterselect = 4;
+			    parameter   charge_pump_current_bits = 9999;
+			    parameter   loop_filter_c_bits = 9999;
+			    parameter   loop_filter_r_bits = 9999;
+			    parameter   scan_chain_mif_file = "UNUSED";
+			    parameter   clk9_multiply_by        = 1;
+			    parameter   clk8_multiply_by        = 1;
+			    parameter   clk7_multiply_by        = 1;
+			    parameter   clk6_multiply_by        = 1;
+			    parameter   clk5_multiply_by        = 1;
+			    parameter   clk4_multiply_by        = 1;
+			    parameter   clk3_multiply_by        = 1;
+			    parameter   clk2_multiply_by        = 1;
+			    parameter   clk1_multiply_by        = 1;
+			    parameter   clk0_multiply_by        = 1;
+			    parameter   clk9_divide_by          = 1;
+			    parameter   clk8_divide_by          = 1;
+			    parameter   clk7_divide_by          = 1;
+			    parameter   clk6_divide_by          = 1;
+			    parameter   clk5_divide_by          = 1;
+			    parameter   clk4_divide_by          = 1;
+			    parameter   clk3_divide_by          = 1;
+			    parameter   clk2_divide_by          = 1;
+			    parameter   clk1_divide_by          = 1;
+			    parameter   clk0_divide_by          = 1;
+			    parameter   clk9_phase_shift        = "0";
+			    parameter   clk8_phase_shift        = "0";
+			    parameter   clk7_phase_shift        = "0";
+			    parameter   clk6_phase_shift        = "0";
+			    parameter   clk5_phase_shift        = "0";
+			    parameter   clk4_phase_shift        = "0";
+			    parameter   clk3_phase_shift        = "0";
+			    parameter   clk2_phase_shift        = "0";
+			    parameter   clk1_phase_shift        = "0";
+			    parameter   clk0_phase_shift        = "0";
+			    
+			    parameter   clk9_duty_cycle         = 50;
+			    parameter   clk8_duty_cycle         = 50;
+			    parameter   clk7_duty_cycle         = 50;
+			    parameter   clk6_duty_cycle         = 50;
+			    parameter   clk5_duty_cycle         = 50;
+			    parameter   clk4_duty_cycle         = 50;
+			    parameter   clk3_duty_cycle         = 50;
+			    parameter   clk2_duty_cycle         = 50;
+			    parameter   clk1_duty_cycle         = 50;
+			    parameter   clk0_duty_cycle         = 50;
+
+			    parameter   clk9_use_even_counter_mode    = "OFF";
+			    parameter   clk8_use_even_counter_mode    = "OFF";
+			    parameter   clk7_use_even_counter_mode    = "OFF";
+			    parameter   clk6_use_even_counter_mode    = "OFF";
+			    parameter   clk5_use_even_counter_mode    = "OFF";
+			    parameter   clk4_use_even_counter_mode    = "OFF";
+			    parameter   clk3_use_even_counter_mode    = "OFF";
+			    parameter   clk2_use_even_counter_mode    = "OFF";
+			    parameter   clk1_use_even_counter_mode    = "OFF";
+			    parameter   clk0_use_even_counter_mode    = "OFF";
+			    parameter   clk9_use_even_counter_value   = "OFF";
+			    parameter   clk8_use_even_counter_value   = "OFF";
+			    parameter   clk7_use_even_counter_value   = "OFF";
+			    parameter   clk6_use_even_counter_value   = "OFF";
+			    parameter   clk5_use_even_counter_value   = "OFF";
+			    parameter   clk4_use_even_counter_value   = "OFF";
+			    parameter   clk3_use_even_counter_value   = "OFF";
+			    parameter   clk2_use_even_counter_value   = "OFF";
+			    parameter   clk1_use_even_counter_value   = "OFF";
+			    parameter   clk0_use_even_counter_value   = "OFF";
+
+			    parameter   clk2_output_frequency   = 0;
+			    parameter   clk1_output_frequency   = 0;
+			    parameter   clk0_output_frequency   = 0;
+
+			    parameter   vco_min             = 0;
+			    parameter   vco_max             = 0;
+			    parameter   vco_center          = 0;
+			    parameter   pfd_min             = 0;
+			    parameter   pfd_max             = 0;
+			    parameter   m_initial           = 1;
+			    parameter   m                   = 0; 
+			    parameter   n                   = 1;
+			    parameter   m2                  = 1;
+			    parameter   n2                  = 1;
+			    parameter   ss                  = 0;
+			    parameter   l0_high             = 1;
+			    parameter   l1_high             = 1;
+			    parameter   g0_high             = 1;
+			    parameter   g1_high             = 1;
+			    parameter   g2_high             = 1;
+			    parameter   g3_high             = 1;
+			    parameter   e0_high             = 1;
+			    parameter   e1_high             = 1;
+			    parameter   e2_high             = 1;
+			    parameter   e3_high             = 1;
+			    parameter   l0_low              = 1;
+			    parameter   l1_low              = 1;
+			    parameter   g0_low              = 1;
+			    parameter   g1_low              = 1;
+			    parameter   g2_low              = 1;
+			    parameter   g3_low              = 1;
+			    parameter   e0_low              = 1;
+			    parameter   e1_low              = 1;
+			    parameter   e2_low              = 1;
+			    parameter   e3_low              = 1;
+			    parameter   l0_initial          = 1;
+			    parameter   l1_initial          = 1;
+			    parameter   g0_initial          = 1;
+			    parameter   g1_initial          = 1;
+			    parameter   g2_initial          = 1;
+			    parameter   g3_initial          = 1;
+			    parameter   e0_initial          = 1;
+			    parameter   e1_initial          = 1;
+			    parameter   e2_initial          = 1;
+			    parameter   e3_initial          = 1;
+			    parameter   l0_mode             = "bypass";
+			    parameter   l1_mode             = "bypass";
+			    parameter   g0_mode             = "bypass";
+			    parameter   g1_mode             = "bypass";
+			    parameter   g2_mode             = "bypass";
+			    parameter   g3_mode             = "bypass";
+			    parameter   e0_mode             = "bypass";
+			    parameter   e1_mode             = "bypass";
+			    parameter   e2_mode             = "bypass";
+			    parameter   e3_mode             = "bypass";
+			    parameter   l0_ph               = 0;
+			    parameter   l1_ph               = 0;
+			    parameter   g0_ph               = 0;
+			    parameter   g1_ph               = 0;
+			    parameter   g2_ph               = 0;
+			    parameter   g3_ph               = 0;
+			    parameter   e0_ph               = 0;
+			    parameter   e1_ph               = 0;
+			    parameter   e2_ph               = 0;
+			    parameter   e3_ph               = 0;
+			    parameter   m_ph                = 0;
+			    parameter   l0_time_delay       = 0;
+			    parameter   l1_time_delay       = 0;
+			    parameter   g0_time_delay       = 0;
+			    parameter   g1_time_delay       = 0;
+			    parameter   g2_time_delay       = 0;
+			    parameter   g3_time_delay       = 0;
+			    parameter   e0_time_delay       = 0;
+			    parameter   e1_time_delay       = 0;
+			    parameter   e2_time_delay       = 0;
+			    parameter   e3_time_delay       = 0;
+			    parameter   m_time_delay        = 0;
+			    parameter   n_time_delay        = 0;
+			    parameter   extclk3_counter     = "e3" ;
+			    parameter   extclk2_counter     = "e2" ;
+			    parameter   extclk1_counter     = "e1" ;
+			    parameter   extclk0_counter     = "e0" ;
+			    parameter   clk9_counter        = "c9" ;
+			    parameter   clk8_counter        = "c8" ;
+			    parameter   clk7_counter        = "c7" ;
+			    parameter   clk6_counter        = "c6" ;
+			    parameter   clk5_counter        = "l1" ;
+			    parameter   clk4_counter        = "l0" ;
+			    parameter   clk3_counter        = "g3" ;
+			    parameter   clk2_counter        = "g2" ;
+			    parameter   clk1_counter        = "g1" ;
+			    parameter   clk0_counter        = "g0" ;
+			    parameter   enable0_counter     = "l0";
+			    parameter   enable1_counter     = "l0";
+			    parameter   charge_pump_current = 2;
+			    parameter   loop_filter_r       = "1.0";
+			    parameter   loop_filter_c       = 5;
+			    parameter   vco_post_scale      = 0;
+			    parameter   vco_frequency_control = "AUTO";
+			    parameter   vco_phase_shift_step = 0;
+			    parameter   lpm_type            = "altpll";
+
+			    parameter port_clkena0 = "PORT_CONNECTIVITY";
+			    parameter port_clkena1 = "PORT_CONNECTIVITY";
+			    parameter port_clkena2 = "PORT_CONNECTIVITY";
+			    parameter port_clkena3 = "PORT_CONNECTIVITY";
+			    parameter port_clkena4 = "PORT_CONNECTIVITY";
+			    parameter port_clkena5 = "PORT_CONNECTIVITY";
+			    parameter port_extclkena0 = "PORT_CONNECTIVITY";
+			    parameter port_extclkena1 = "PORT_CONNECTIVITY";
+			    parameter port_extclkena2 = "PORT_CONNECTIVITY";
+			    parameter port_extclkena3 = "PORT_CONNECTIVITY";
+			    parameter port_extclk0 = "PORT_CONNECTIVITY";
+			    parameter port_extclk1 = "PORT_CONNECTIVITY";
+			    parameter port_extclk2 = "PORT_CONNECTIVITY";
+			    parameter port_extclk3 = "PORT_CONNECTIVITY";
+			    parameter port_clk0 = "PORT_CONNECTIVITY";
+			    parameter port_clk1 = "PORT_CONNECTIVITY";
+			    parameter port_clk2 = "PORT_CONNECTIVITY";
+			    parameter port_clk3 = "PORT_CONNECTIVITY";
+			    parameter port_clk4 = "PORT_CONNECTIVITY";
+			    parameter port_clk5 = "PORT_CONNECTIVITY";
+			    parameter port_clk6 = "PORT_CONNECTIVITY";
+			    parameter port_clk7 = "PORT_CONNECTIVITY";
+			    parameter port_clk8 = "PORT_CONNECTIVITY";
+			    parameter port_clk9 = "PORT_CONNECTIVITY";
+			    parameter port_scandata = "PORT_CONNECTIVITY";
+			    parameter port_scandataout = "PORT_CONNECTIVITY";
+			    parameter port_scandone = "PORT_CONNECTIVITY";
+			    parameter port_sclkout1 = "PORT_CONNECTIVITY";
+			    parameter port_sclkout0 = "PORT_CONNECTIVITY";
+			    parameter port_clkbad0 = "PORT_CONNECTIVITY";
+			    parameter port_clkbad1 = "PORT_CONNECTIVITY";
+			    parameter port_activeclock = "PORT_CONNECTIVITY";
+			    parameter port_clkloss = "PORT_CONNECTIVITY";
+			    parameter port_inclk1 = "PORT_CONNECTIVITY";
+			    parameter port_inclk0 = "PORT_CONNECTIVITY";
+			    parameter port_fbin = "PORT_CONNECTIVITY";
+			    parameter port_fbout = "PORT_CONNECTIVITY";
+			    parameter port_pllena = "PORT_CONNECTIVITY";
+			    parameter port_clkswitch = "PORT_CONNECTIVITY";
+			    parameter port_areset = "PORT_CONNECTIVITY";
+			    parameter port_pfdena = "PORT_CONNECTIVITY";
+			    parameter port_scanclk = "PORT_CONNECTIVITY";
+			    parameter port_scanaclr = "PORT_CONNECTIVITY";
+			    parameter port_scanread = "PORT_CONNECTIVITY";
+			    parameter port_scanwrite = "PORT_CONNECTIVITY";
+			    parameter port_enable0 = "PORT_CONNECTIVITY";
+			    parameter port_enable1 = "PORT_CONNECTIVITY";
+			    parameter port_locked = "PORT_CONNECTIVITY";
+			    parameter port_configupdate = "PORT_CONNECTIVITY";
+			    parameter port_phasecounterselect = "PORT_CONNECTIVITY";
+			    parameter port_phasedone = "PORT_CONNECTIVITY";
+			    parameter port_phasestep = "PORT_CONNECTIVITY";
+			    parameter port_phaseupdown = "PORT_CONNECTIVITY";
+			    parameter port_vcooverrange = "PORT_CONNECTIVITY";
+			    parameter port_vcounderrange = "PORT_CONNECTIVITY";
+			    parameter port_scanclkena = "PORT_CONNECTIVITY";
+			    parameter using_fbmimicbidir_port = "ON";
+
+endmodule

--- a/techlibs/altera_intel/max10/cells_arith_max10.v
+++ b/techlibs/altera_intel/max10/cells_arith_max10.v
@@ -1,0 +1,61 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+ 
+(* techmap_celltype = "$alu" *)
+module _80_altera_max10_alu (A, B, CI, BI, X, Y, CO);
+   parameter A_SIGNED = 0;
+   parameter B_SIGNED = 0;
+   parameter A_WIDTH  = 1;
+   parameter B_WIDTH  = 1;
+   parameter Y_WIDTH  = 1;
+   parameter LUT      = 0;
+   
+   input [A_WIDTH-1:0] A;
+   input [B_WIDTH-1:0] B;
+   output [Y_WIDTH-1:0] X, Y;
+
+   input 		CI, BI;
+   output [Y_WIDTH-1:0] CO;
+
+   wire 		_TECHMAP_FAIL_ = Y_WIDTH <= 2;
+
+   wire                 tempcombout;
+   wire [Y_WIDTH-1:0] 	A_buf, B_buf;
+   \$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
+   \$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+
+   wire [Y_WIDTH-1:0] AA = A_buf;
+   wire [Y_WIDTH-1:0] BB = BI ? ~B_buf : B_buf;
+   wire [Y_WIDTH-1:0] C = {CO, CI};
+   
+   genvar i;
+	generate for (i = 0; i < Y_WIDTH; i = i + 1) begin:slice
+	   fiftyfivenm_lcell_comb #(.lut_mask(LUT), .sum_lutc_input("cin")) _TECHMAP_REPLACE_ 
+	                                                                             ( .dataa(AA), 
+										       .datab(BB), 
+										       .datac(C), 
+										       .datad(1'b0), 
+										       .cin(C[i]), 
+										       .cout(CO[i]),
+										       .combout(Y[i]) );
+	  end: slice
+	endgenerate
+  assign X = C;
+endmodule
+   

--- a/techlibs/altera_intel/max10/cells_comb_max10.v
+++ b/techlibs/altera_intel/max10/cells_comb_max10.v
@@ -1,0 +1,111 @@
+module VCC (output V);
+   assign V = 1'b1;
+endmodule // VCC
+
+module GND (output G);
+   assign G = 1'b0;
+endmodule // GND
+
+/* Altera MAX10 devices Input Buffer Primitive */ 
+module fiftyfivenm_io_ibuf (output o, input i, input ibar);
+   assign ibar = ibar;
+   assign o    = i;
+endmodule // fiftyfivenm_io_ibuf
+
+/* Altera MAX10 devices Output Buffer Primitive */
+module fiftyfivenm_io_obuf (output o, input i, input oe);
+   assign o  = i;
+   assign oe = oe;
+endmodule // fiftyfivenm_io_obuf
+
+/* Altera MAX10 4-input non-fracturable LUT Primitive */ 
+module fiftyfivenm_lcell_comb (output combout, cout,
+                               input  dataa, datab, datac, datad, cin);
+
+/* Internal parameters which define the behaviour
+   of the LUT primitive.
+   lut_mask define the lut function, can be expressed in 16-digit bin or hex.
+   sum_lutc_input define the type of LUT (combinational | arithmetic). 
+   dont_touch for retiming || carry options.
+   lpm_type for WYSIWYG */  
+   
+parameter lut_mask = 16'hFFFF;
+parameter sum_lutc_input = "datac";
+parameter dont_touch = "off";
+parameter lpm_type = "fiftyfivenm_lcell_comb";
+  
+reg [1:0] lut_type;  
+reg cout_rt;
+reg combout_rt;
+
+wire dataa_w;
+wire datab_w;
+wire datac_w;
+wire datad_w;
+wire cin_w;
+
+assign dataa_w = dataa;
+assign datab_w = datab;
+assign datac_w = datac;
+assign datad_w = datad;
+
+function lut_data;
+input [15:0] mask;
+input dataa;
+input datab;
+input datac;
+input datad;
+
+  begin
+    lut_data = datad ? (datac ? (datab ? (dataa ? mask[15] : mask[14]) : (dataa ?  mask[13] : mask[12])) 
+                     : (datab ? (dataa ? mask[11] : mask[10]) : (dataa ?  mask[ 9] : mask[ 8])))
+                     : (datac ? (datab ? ( dataa ? mask[7] : mask[6]) : (dataa ?  mask[5] : mask[4])) 
+                     : (datab ? (dataa ? mask[3] : mask[2]) : ( dataa ? mask[1] : mask[0])));
+  end
+
+endfunction
+
+initial begin
+    if (sum_lutc_input == "datac") lut_type = 0;
+    else 
+    if (sum_lutc_input == "cin")   lut_type = 1;
+    else                           lut_type = 2;
+end
+
+always @(dataa_w or datab_w or datac_w or datad_w or cin_w) begin
+    if (lut_type == 0) begin
+        combout_rt = lut_data(lut_mask, dataa_w, datab_w, 
+                            datac_w, datad_w);
+    end
+    else if (lut_type == 1) begin
+        combout_rt = lut_data(lut_mask, dataa_w, datab_w, 
+                            cin_w, datad_w);
+    end
+    cout_rt = lut_data(lut_mask, dataa_w, datab_w, cin_w, 'b0);
+end
+
+assign combout = combout_rt & 1'b1;
+assign cout = cout_rt & 1'b1;
+
+endmodule // fiftyfivenm_lcell_comb
+
+// DFF
+module dffeas #(parameter power_up="dontcare", is_wysiwyg="false") ( output q, 
+								     input d, 
+								     input clk, 
+								     input clrn, 
+								     input prn, 
+								     input ena, 
+								     input asdata, 
+								     input aload, 
+								     input sclr, 
+  								     input sload );
+  reg q;
+
+  always @(posedge clk)
+    q <= d;
+   
+endmodule
+
+
+

--- a/techlibs/altera_intel/max10/cells_map_max10.v
+++ b/techlibs/altera_intel/max10/cells_map_max10.v
@@ -1,0 +1,43 @@
+// Flip-flop D
+module  \$_DFF_P_ (input D, input C, output Q);
+   parameter WYSIWYG="TRUE";
+   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+endmodule //
+
+// Input buffer map
+module \$__inpad (input I, output O);
+    fiftyfivenm_io_ibuf _TECHMAP_REPLACE_ (.o(O), .i(I), .ibar(1'b0));
+endmodule 
+
+// Output buffer map   
+module \$__outpad (input I, output O);
+    fiftyfivenm_io_obuf _TECHMAP_REPLACE_ (.o(O), .i(I), .oe(1'b1));
+endmodule 
+
+// LUT Map
+/* 0 -> datac
+   1 -> cin */
+module \$lut (A, Y);
+   parameter WIDTH  = 0;
+   parameter LUT    = 0;
+   parameter SPLIT4 = {LUT[15:12], LUT[7:4], LUT[11:8], LUT[3:0]}; // used for 4-in luts, KISS;
+   input [WIDTH-1:0] A;
+   output 	     Y;
+   generate 
+      if (WIDTH == 1) begin
+	   assign Y = ~A[0]; // Not need to spend 1 logic cell for such an easy function
+      end else
+      if (WIDTH == 2) begin
+           fiftyfivenm_lcell_comb #(.lut_mask({4{LUT}}), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(1'b1),.datad(1'b1));
+      end else
+      if(WIDTH == 3) begin 
+	   fiftyfivenm_lcell_comb #(.lut_mask({2{LUT}}), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(A[2]),.datad(1'b1));
+      end else
+      if(WIDTH == 4) begin
+	   fiftyfivenm_lcell_comb #(.lut_mask(LUT), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(A[2]),.datad(A[3]));
+      end else
+	   wire _TECHMAP_FAIL_ = 1;
+   endgenerate
+endmodule //
+
+	    

--- a/techlibs/altera_intel/synth_intel.cc
+++ b/techlibs/altera_intel/synth_intel.cc
@@ -1,0 +1,199 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/register.h"
+#include "kernel/celltypes.h"
+#include "kernel/rtlil.h"
+#include "kernel/log.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct SynthIntelPass : public ScriptPass {
+	SynthIntelPass() : ScriptPass("synth_intel", "synthesis for Intel (Altera) FPGAs.") { }
+
+	virtual void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    synth_intel [options]\n");
+		log("\n");
+		log("This command runs synthesis for Intel FPGAs. This work is still experimental.\n");
+		log("\n");
+		log("    -family < max10 | cycloneiv >\n");
+		log("        generate the synthesis netlist for the specified family.\n");
+		log("        MAX10 is the default target if not family argument specified \n");
+		log("\n");
+		log("    -top <module>\n");
+		log("        use the specified module as top module (default='top')\n");
+		log("\n");
+		log("    -vout <file>\n");
+		log("        write the design to the specified Verilog netlist file. writing of an\n");
+		log("        output file is omitted if this parameter is not specified.\n");
+		log("\n");
+		log("    -run <from_label>:<to_label>\n");
+		log("        only run the commands between the labels (see below). an empty\n");
+		log("        from label is synonymous to 'begin', and empty to label is\n");
+		log("        synonymous to the end of the command list.\n");
+		log("\n");
+		log("    -retime\n");
+		log("        run 'abc' with -dff option\n");
+		log("\n");
+		log("\n");
+		log("The following commands are executed by this synthesis command:\n");
+		help_script();
+		log("\n");
+	}
+
+        string top_opt, family_opt, vout_file;
+	bool retime;
+
+	virtual void clear_flags() YS_OVERRIDE
+	{
+		top_opt = "-auto-top";
+                family_opt = "max10";
+		vout_file = "";
+		retime = false;
+	}
+
+	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+	  string run_from, run_to;
+		clear_flags();
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++)
+		{
+		        if (args[argidx] == "-family" && argidx+1 < args.size()) {
+				family_opt = args[++argidx];
+				continue;
+			}
+			if (args[argidx] == "-top" && argidx+1 < args.size()) {
+				top_opt = "-top " + args[++argidx];
+				continue;
+			}
+			if (args[argidx] == "-vout" && argidx+1 < args.size()) {
+				vout_file = args[++argidx];
+				continue;
+			}
+			if (args[argidx] == "-run" && argidx+1 < args.size()) {
+				size_t pos = args[argidx+1].find(':');
+				if (pos == std::string::npos)
+					break;
+				run_from = args[++argidx].substr(0, pos);
+				run_to = args[argidx].substr(pos+1);
+				continue;
+			}
+			if (args[argidx] == "-retime") {
+				retime = true;
+				continue;
+			}
+			break;
+		}
+		extra_args(args, argidx, design);
+
+		if (!design->full_selection())
+			log_cmd_error("This comannd only operates on fully selected designs!\n");
+		
+                if (family_opt != "max10" && family_opt !="cycloneiv" )
+		  log_cmd_error("Invalid or not family specified: '%s'\n", family_opt.c_str());
+
+		log_header(design, "Executing SYNTH_INTEL pass.\n");
+		log_push();
+
+		run_script(design, run_from, run_to);
+
+		log_pop();
+	}
+
+	virtual void script() YS_OVERRIDE
+	{
+	  if (check_label("begin"))
+	  {
+		  if(check_label("family") && family_opt=="max10")
+		  {
+			run("read_verilog -lib +/altera_intel/max10/cells_comb_max10.v");
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+		  }
+		  else
+		  {
+		      run("read_verilog -lib +/altera_intel/cycloneiv/cells_comb_cycloneiv.v");
+		      run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+		  }
+	  }
+
+		if (check_label("flatten"))
+		{
+			run("proc");
+			run("flatten");
+			run("tribuf -logic");
+			run("deminout");
+		}
+
+		if (check_label("coarse"))
+		{
+			run("synth -run coarse");
+		}
+
+		if (check_label("fine"))
+		{
+		        run("opt -fast -full");
+			run("memory_map");
+			run("opt -full");
+			run("techmap -map +/techmap.v");
+                        run("opt -fast");
+			run("clean -purge");
+			run("setundef -undriven -zero");
+			if (retime || help_mode)
+				run("abc -dff", "(only if -retime)");
+		}
+
+		if (check_label("map_luts"))
+		{
+		        run("abc -lut 4");
+			run("clean");
+		}
+
+		if (check_label("map_cells"))
+		{
+			run("iopadmap -bits -outpad $__outpad I:O -inpad $__inpad O:I");
+			if(family_opt=="max10")
+			  run("techmap -map +/altera_intel/max10/cells_map_max10.v");
+			else
+			  run("techmap -map +/altera_intel/cycloneiv/cells_map_cycloneiv.v");
+			run("clean -purge");
+		}
+
+		if (check_label("check"))
+		{
+			run("hierarchy -check");
+			run("stat");
+			run("check -noinit");
+		}
+
+		if (check_label("vout"))
+		{
+			if (!vout_file.empty() || help_mode)
+				run(stringf("write_verilog -nodec -attr2comment -defparam -nohex -renameprefix yosys_ %s",
+						help_mode ? "<file-name>" : vout_file.c_str()));
+		}
+	}
+} SynthIntelPass;
+
+PRIVATE_NAMESPACE_END


### PR DESCRIPTION
This pull request is to add the MAX10 and Cyclone IV FPGA initial Yosys support of those families.

This work contains a tested way to generate Verilog Quartus Mapping file to pass to Quartus Place and Route tools. Only combinational and few sequential designs are supported at this time, please see the examples/intel designs for more understanding, and some scripts to interface Yosys and Quartus.

Some of the generated netlist was tested in real hardware, such as the DE2i-150 and MAX10 development kits.

Post synthesis simulation is also supported.

Please read CHANGELOG.