### PR TITLE
Add initial support for both MAX10 and Cyclone IV (E|GX) FPGAs

### DIFF
--- a/examples/intel/DE2i-150/quartus_compile/de2i.qpf
+++ b/examples/intel/DE2i-150/quartus_compile/de2i.qpf
@@ -1,0 +1,4 @@
+QUARTUS_VERSION = "16.1"
+# Revisions
+
+PROJECT_REVISION = "de2i"

--- a/examples/intel/DE2i-150/quartus_compile/de2i.qsf
+++ b/examples/intel/DE2i-150/quartus_compile/de2i.qsf
@@ -1,0 +1,1099 @@
+set_global_assignment -name FAMILY "Cyclone IV GX"
+set_global_assignment -name DEVICE EP4CGX150DF31C7
+set_global_assignment -name TOP_LEVEL_ENTITY "top"
+set_global_assignment -name DEVICE_FILTER_PACKAGE FBGA
+
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to CLOCK2_50
+set_instance_assignment -name IO_STANDARD "2.5 V" -to CLOCK3_50
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to CLOCK_50
+
+#============================================================
+# DRAM
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_ADDR[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_BA[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_BA[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_CAS_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_CKE
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_CLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_CS_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[16]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[17]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[18]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[19]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[20]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[21]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[22]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[23]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[24]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[25]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[26]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[27]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[28]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[29]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[30]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQ[31]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQM[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQM[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQM[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_DQM[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_RAS_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to DRAM_WE_N
+
+#============================================================
+# EEP
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to EEP_I2C_SCLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to EEP_I2C_SDAT
+
+#============================================================
+# ENET
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_GTX_CLK
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_INT_N
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_LINK100
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_MDC
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_MDIO
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RST_N
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_CLK
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_COL
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_CRS
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_DATA[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_DATA[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_DATA[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_DATA[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_DV
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_RX_ER
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_CLK
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_DATA[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_DATA[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_DATA[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_DATA[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_EN
+set_instance_assignment -name IO_STANDARD "2.5 V" -to ENET_TX_ER
+
+#============================================================
+# FAN
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to FAN_CTRL
+
+#============================================================
+# FLASH
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_RESET_N
+
+#============================================================
+# FS
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[16]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[17]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[18]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[19]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[20]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[21]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[22]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[23]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[24]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[25]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_ADDR[26]
+
+#============================================================
+# FL
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_CE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_OE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_RY
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_WE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FL_WP_N
+
+#============================================================
+# FS
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[16]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[17]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[18]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[19]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[20]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[21]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[22]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[23]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[24]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[25]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[26]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[27]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[28]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[29]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[30]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to FS_DQ[31]
+
+#============================================================
+# GPIO
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[8]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[9]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[10]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[11]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[12]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[13]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[14]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[15]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[16]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[17]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[18]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[19]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[20]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[21]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[22]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[23]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[24]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[25]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[26]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[27]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[28]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[29]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[30]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[31]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[32]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[33]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[34]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[35]
+
+#============================================================
+# G
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to G_SENSOR_INT1
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to G_SENSOR_SCLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to G_SENSOR_SDAT
+
+#============================================================
+# HEX0
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX0[6]
+
+#============================================================
+# HEX1
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX1[6]
+
+#============================================================
+# HEX2
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX2[6]
+
+#============================================================
+# HEX3
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX3[6]
+
+#============================================================
+# HEX4
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX4[6]
+
+#============================================================
+# HEX5
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX5[6]
+
+#============================================================
+# HEX6
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX6[6]
+
+#============================================================
+# HEX7
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HEX7[6]
+
+#============================================================
+# HSMC
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKIN0
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKIN_N1
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKIN_N2
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKIN_P1
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKIN_P2
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKOUT0
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKOUT_N1
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKOUT_N2
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKOUT_P1
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_CLKOUT_P2
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_D[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_D[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_D[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_D[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_I2C_SCLK
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_I2C_SDAT
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_N[16]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_RX_D_P[16]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_N[16]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to HSMC_TX_D_P[16]
+
+#============================================================
+# I2C
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to I2C_SCLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to I2C_SDAT
+
+#============================================================
+# IRDA
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to IRDA_RXD
+
+#============================================================
+# KEY
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to KEY[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to KEY[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to KEY[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to KEY[3]
+
+#============================================================
+# LCD
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_DATA[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_EN
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LCD_ON
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_RS
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to LCD_RW
+
+#============================================================
+# LEDG
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDG[8]
+
+#============================================================
+# LEDR
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[16]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to LEDR[17]
+
+#============================================================
+# PCIE
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to PCIE_PERST_N
+set_instance_assignment -name IO_STANDARD HCSL -to PCIE_REFCLK_P
+set_instance_assignment -name IO_STANDARD "1.5-V PCML" -to PCIE_RX_P[0]
+set_instance_assignment -name IO_STANDARD "1.5-V PCML" -to PCIE_RX_P[1]
+set_instance_assignment -name IO_STANDARD "1.5-V PCML" -to PCIE_TX_P[0]
+set_instance_assignment -name IO_STANDARD "1.5-V PCML" -to PCIE_TX_P[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to PCIE_WAKE_N
+
+#============================================================
+# SD
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_CLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_CMD
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_DAT[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_DAT[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_DAT[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_DAT[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SD_WP_N
+
+#============================================================
+# SMA
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SMA_CLKIN
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SMA_CLKOUT
+
+#============================================================
+# SSRAM0
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM0_CE_N
+
+#============================================================
+# SSRAM1
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM1_CE_N
+
+#============================================================
+# SSRAM
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_ADSC_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_ADSP_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_ADV_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_BE[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_BE[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_BE[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_BE[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_CLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_GW_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_OE_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to SSRAM_WE_N
+
+#============================================================
+# SW
+#============================================================
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[0]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[1]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[2]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[3]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[4]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[5]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[6]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[7]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[8]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[9]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[10]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[11]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[12]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[13]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[14]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[15]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[16]
+set_instance_assignment -name IO_STANDARD "2.5 V" -to SW[17]
+
+#============================================================
+# TD
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_CLK27
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_DATA[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_HS
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_RESET_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to TD_VS
+
+#============================================================
+# UART
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to UART_CTS
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to UART_RTS
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to UART_RXD
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to UART_TXD
+
+#============================================================
+# VGA
+#============================================================
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_B[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_BLANK_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_CLK
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_G[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_HS
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_R[7]
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_SYNC_N
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_VS
+
+#============================================================
+# End of pin assignments by Terasic System Builder
+#============================================================
+
+
+
+set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION "USE AS REGULAR IO"
+set_location_assignment PIN_A15 -to CLOCK2_50
+set_location_assignment PIN_V11 -to CLOCK3_50
+set_location_assignment PIN_AJ16 -to CLOCK_50
+set_location_assignment PIN_AG7 -to DRAM_ADDR[0]
+set_location_assignment PIN_AJ7 -to DRAM_ADDR[1]
+set_location_assignment PIN_AG8 -to DRAM_ADDR[2]
+set_location_assignment PIN_AH8 -to DRAM_ADDR[3]
+set_location_assignment PIN_AE16 -to DRAM_ADDR[4]
+set_location_assignment PIN_AF16 -to DRAM_ADDR[5]
+set_location_assignment PIN_AE14 -to DRAM_ADDR[6]
+set_location_assignment PIN_AE15 -to DRAM_ADDR[7]
+set_location_assignment PIN_AE13 -to DRAM_ADDR[8]
+set_location_assignment PIN_AE12 -to DRAM_ADDR[9]
+set_location_assignment PIN_AH6 -to DRAM_ADDR[10]
+set_location_assignment PIN_AE11 -to DRAM_ADDR[11]
+set_location_assignment PIN_AE10 -to DRAM_ADDR[12]
+set_location_assignment PIN_AH5 -to DRAM_BA[0]
+set_location_assignment PIN_AG6 -to DRAM_BA[1]
+set_location_assignment PIN_AJ4 -to DRAM_CAS_N
+set_location_assignment PIN_AD6 -to DRAM_CKE
+set_location_assignment PIN_AE6 -to DRAM_CLK
+set_location_assignment PIN_AG5 -to DRAM_CS_N
+set_location_assignment PIN_AD10 -to DRAM_DQ[0]
+set_location_assignment PIN_AD9 -to DRAM_DQ[1]
+set_location_assignment PIN_AE9 -to DRAM_DQ[2]
+set_location_assignment PIN_AE8 -to DRAM_DQ[3]
+set_location_assignment PIN_AE7 -to DRAM_DQ[4]
+set_location_assignment PIN_AF7 -to DRAM_DQ[5]
+set_location_assignment PIN_AF6 -to DRAM_DQ[6]
+set_location_assignment PIN_AF9 -to DRAM_DQ[7]
+set_location_assignment PIN_AB13 -to DRAM_DQ[8]
+set_location_assignment PIN_AF13 -to DRAM_DQ[9]
+set_location_assignment PIN_AF12 -to DRAM_DQ[10]
+set_location_assignment PIN_AG9 -to DRAM_DQ[11]
+set_location_assignment PIN_AA13 -to DRAM_DQ[12]
+set_location_assignment PIN_AB11 -to DRAM_DQ[13]
+set_location_assignment PIN_AA12 -to DRAM_DQ[14]
+set_location_assignment PIN_AA15 -to DRAM_DQ[15]
+set_location_assignment PIN_AH11 -to DRAM_DQ[16]
+set_location_assignment PIN_AG11 -to DRAM_DQ[17]
+set_location_assignment PIN_AH12 -to DRAM_DQ[18]
+set_location_assignment PIN_AG12 -to DRAM_DQ[19]
+set_location_assignment PIN_AH13 -to DRAM_DQ[20]
+set_location_assignment PIN_AG13 -to DRAM_DQ[21]
+set_location_assignment PIN_AG14 -to DRAM_DQ[22]
+set_location_assignment PIN_AH14 -to DRAM_DQ[23]
+set_location_assignment PIN_AH9 -to DRAM_DQ[24]
+set_location_assignment PIN_AK8 -to DRAM_DQ[25]
+set_location_assignment PIN_AG10 -to DRAM_DQ[26]
+set_location_assignment PIN_AK7 -to DRAM_DQ[27]
+set_location_assignment PIN_AH7 -to DRAM_DQ[28]
+set_location_assignment PIN_AK6 -to DRAM_DQ[29]
+set_location_assignment PIN_AJ6 -to DRAM_DQ[30]
+set_location_assignment PIN_AK5 -to DRAM_DQ[31]
+set_location_assignment PIN_AF10 -to DRAM_DQM[0]
+set_location_assignment PIN_AB14 -to DRAM_DQM[1]
+set_location_assignment PIN_AH15 -to DRAM_DQM[2]
+set_location_assignment PIN_AH10 -to DRAM_DQM[3]
+set_location_assignment PIN_AK4 -to DRAM_RAS_N
+set_location_assignment PIN_AK3 -to DRAM_WE_N
+set_location_assignment PIN_AG27 -to EEP_I2C_SCLK
+set_location_assignment PIN_AG25 -to EEP_I2C_SDAT
+set_location_assignment PIN_A12 -to ENET_GTX_CLK
+set_location_assignment PIN_E16 -to ENET_INT_N
+set_location_assignment PIN_F5 -to ENET_LINK100
+set_location_assignment PIN_C16 -to ENET_MDC
+set_location_assignment PIN_C15 -to ENET_MDIO
+set_location_assignment PIN_C14 -to ENET_RST_N
+set_location_assignment PIN_L15 -to ENET_RX_CLK
+set_location_assignment PIN_G15 -to ENET_RX_COL
+set_location_assignment PIN_D6 -to ENET_RX_CRS
+set_location_assignment PIN_F15 -to ENET_RX_DATA[0]
+set_location_assignment PIN_E13 -to ENET_RX_DATA[1]
+set_location_assignment PIN_A5 -to ENET_RX_DATA[2]
+set_location_assignment PIN_B7 -to ENET_RX_DATA[3]
+set_location_assignment PIN_A8 -to ENET_RX_DV
+set_location_assignment PIN_D11 -to ENET_RX_ER
+set_location_assignment PIN_F13 -to ENET_TX_CLK
+set_location_assignment PIN_B12 -to ENET_TX_DATA[0]
+set_location_assignment PIN_E7 -to ENET_TX_DATA[1]
+set_location_assignment PIN_C13 -to ENET_TX_DATA[2]
+set_location_assignment PIN_D15 -to ENET_TX_DATA[3]
+set_location_assignment PIN_D14 -to ENET_TX_EN
+set_location_assignment PIN_D13 -to ENET_TX_ER
+set_location_assignment PIN_AF28 -to FAN_CTRL
+set_location_assignment PIN_AG18 -to FL_RESET_N
+set_location_assignment PIN_AB22 -to FS_ADDR[1]
+set_location_assignment PIN_AH19 -to FS_ADDR[2]
+set_location_assignment PIN_AK19 -to FS_ADDR[3]
+set_location_assignment PIN_AJ18 -to FS_ADDR[4]
+set_location_assignment PIN_AA18 -to FS_ADDR[5]
+set_location_assignment PIN_AH18 -to FS_ADDR[6]
+set_location_assignment PIN_AK17 -to FS_ADDR[7]
+set_location_assignment PIN_Y20 -to FS_ADDR[8]
+set_location_assignment PIN_AK21 -to FS_ADDR[9]
+set_location_assignment PIN_AH21 -to FS_ADDR[10]
+set_location_assignment PIN_AG21 -to FS_ADDR[11]
+set_location_assignment PIN_AG22 -to FS_ADDR[12]
+set_location_assignment PIN_AD22 -to FS_ADDR[13]
+set_location_assignment PIN_AE24 -to FS_ADDR[14]
+set_location_assignment PIN_AD23 -to FS_ADDR[15]
+set_location_assignment PIN_AB21 -to FS_ADDR[16]
+set_location_assignment PIN_AH17 -to FS_ADDR[17]
+set_location_assignment PIN_AE17 -to FS_ADDR[18]
+set_location_assignment PIN_AG20 -to FS_ADDR[19]
+set_location_assignment PIN_AK20 -to FS_ADDR[20]
+set_location_assignment PIN_AE19 -to FS_ADDR[21]
+set_location_assignment PIN_AA16 -to FS_ADDR[22]
+set_location_assignment PIN_AF15 -to FS_ADDR[23]
+set_location_assignment PIN_AG15 -to FS_ADDR[24]
+set_location_assignment PIN_Y17 -to FS_ADDR[25]
+set_location_assignment PIN_AB16 -to FS_ADDR[26]
+set_location_assignment PIN_AG19 -to FL_CE_N
+set_location_assignment PIN_AJ19 -to FL_OE_N
+set_location_assignment PIN_AF19 -to FL_RY
+set_location_assignment PIN_AG17 -to FL_WE_N
+set_location_assignment PIN_AK18 -to FL_WP_N
+set_location_assignment PIN_AK29 -to FS_DQ[0]
+set_location_assignment PIN_AE23 -to FS_DQ[1]
+set_location_assignment PIN_AH24 -to FS_DQ[2]
+set_location_assignment PIN_AH23 -to FS_DQ[3]
+set_location_assignment PIN_AA21 -to FS_DQ[4]
+set_location_assignment PIN_AE20 -to FS_DQ[5]
+set_location_assignment PIN_Y19 -to FS_DQ[6]
+set_location_assignment PIN_AA17 -to FS_DQ[7]
+set_location_assignment PIN_AB17 -to FS_DQ[8]
+set_location_assignment PIN_Y18 -to FS_DQ[9]
+set_location_assignment PIN_AA20 -to FS_DQ[10]
+set_location_assignment PIN_AE21 -to FS_DQ[11]
+set_location_assignment PIN_AH22 -to FS_DQ[12]
+set_location_assignment PIN_AJ24 -to FS_DQ[13]
+set_location_assignment PIN_AE22 -to FS_DQ[14]
+set_location_assignment PIN_AK28 -to FS_DQ[15]
+set_location_assignment PIN_AK9 -to FS_DQ[16]
+set_location_assignment PIN_AJ10 -to FS_DQ[17]
+set_location_assignment PIN_AK11 -to FS_DQ[18]
+set_location_assignment PIN_AK12 -to FS_DQ[19]
+set_location_assignment PIN_AJ13 -to FS_DQ[20]
+set_location_assignment PIN_AK15 -to FS_DQ[21]
+set_location_assignment PIN_AC16 -to FS_DQ[22]
+set_location_assignment PIN_AH16 -to FS_DQ[23]
+set_location_assignment PIN_AG16 -to FS_DQ[24]
+set_location_assignment PIN_AD16 -to FS_DQ[25]
+set_location_assignment PIN_AJ15 -to FS_DQ[26]
+set_location_assignment PIN_AK14 -to FS_DQ[27]
+set_location_assignment PIN_AK13 -to FS_DQ[28]
+set_location_assignment PIN_AJ12 -to FS_DQ[29]
+set_location_assignment PIN_AK10 -to FS_DQ[30]
+set_location_assignment PIN_AJ9 -to FS_DQ[31]
+set_location_assignment PIN_G16 -to GPIO[0]
+set_location_assignment PIN_F17 -to GPIO[1]
+set_location_assignment PIN_D18 -to GPIO[2]
+set_location_assignment PIN_F18 -to GPIO[3]
+set_location_assignment PIN_D19 -to GPIO[4]
+set_location_assignment PIN_K21 -to GPIO[5]
+set_location_assignment PIN_F19 -to GPIO[6]
+set_location_assignment PIN_K22 -to GPIO[7]
+set_location_assignment PIN_B21 -to GPIO[8]
+set_location_assignment PIN_C21 -to GPIO[9]
+set_location_assignment PIN_D22 -to GPIO[10]
+set_location_assignment PIN_D21 -to GPIO[11]
+set_location_assignment PIN_D23 -to GPIO[12]
+set_location_assignment PIN_D24 -to GPIO[13]
+set_location_assignment PIN_B28 -to GPIO[14]
+set_location_assignment PIN_C25 -to GPIO[15]
+set_location_assignment PIN_C26 -to GPIO[16]
+set_location_assignment PIN_D28 -to GPIO[17]
+set_location_assignment PIN_D25 -to GPIO[18]
+set_location_assignment PIN_F20 -to GPIO[19]
+set_location_assignment PIN_E21 -to GPIO[20]
+set_location_assignment PIN_F23 -to GPIO[21]
+set_location_assignment PIN_G20 -to GPIO[22]
+set_location_assignment PIN_F22 -to GPIO[23]
+set_location_assignment PIN_G22 -to GPIO[24]
+set_location_assignment PIN_G24 -to GPIO[25]
+set_location_assignment PIN_G23 -to GPIO[26]
+set_location_assignment PIN_A25 -to GPIO[27]
+set_location_assignment PIN_A26 -to GPIO[28]
+set_location_assignment PIN_A19 -to GPIO[29]
+set_location_assignment PIN_A28 -to GPIO[30]
+set_location_assignment PIN_A27 -to GPIO[31]
+set_location_assignment PIN_B30 -to GPIO[32]
+set_location_assignment PIN_AG28 -to GPIO[33]
+set_location_assignment PIN_AG26 -to GPIO[34]
+set_location_assignment PIN_Y21 -to GPIO[35]
+set_location_assignment PIN_AC30 -to G_SENSOR_INT1
+set_location_assignment PIN_AK27 -to G_SENSOR_SCLK
+set_location_assignment PIN_AK26 -to G_SENSOR_SDAT
+set_location_assignment PIN_E15 -to HEX0[0]
+set_location_assignment PIN_E12 -to HEX0[1]
+set_location_assignment PIN_G11 -to HEX0[2]
+set_location_assignment PIN_F11 -to HEX0[3]
+set_location_assignment PIN_F16 -to HEX0[4]
+set_location_assignment PIN_D16 -to HEX0[5]
+set_location_assignment PIN_F14 -to HEX0[6]
+set_location_assignment PIN_G14 -to HEX1[0]
+set_location_assignment PIN_B13 -to HEX1[1]
+set_location_assignment PIN_G13 -to HEX1[2]
+set_location_assignment PIN_F12 -to HEX1[3]
+set_location_assignment PIN_G12 -to HEX1[4]
+set_location_assignment PIN_J9 -to HEX1[5]
+set_location_assignment PIN_G10 -to HEX1[6]
+set_location_assignment PIN_G8 -to HEX2[0]
+set_location_assignment PIN_G7 -to HEX2[1]
+set_location_assignment PIN_F7 -to HEX2[2]
+set_location_assignment PIN_AG30 -to HEX2[3]
+set_location_assignment PIN_F6 -to HEX2[4]
+set_location_assignment PIN_F4 -to HEX2[5]
+set_location_assignment PIN_F10 -to HEX2[6]
+set_location_assignment PIN_D10 -to HEX3[0]
+set_location_assignment PIN_D7 -to HEX3[1]
+set_location_assignment PIN_E6 -to HEX3[2]
+set_location_assignment PIN_E4 -to HEX3[3]
+set_location_assignment PIN_E3 -to HEX3[4]
+set_location_assignment PIN_D5 -to HEX3[5]
+set_location_assignment PIN_D4 -to HEX3[6]
+set_location_assignment PIN_A14 -to HEX4[0]
+set_location_assignment PIN_A13 -to HEX4[1]
+set_location_assignment PIN_C7 -to HEX4[2]
+set_location_assignment PIN_C6 -to HEX4[3]
+set_location_assignment PIN_C5 -to HEX4[4]
+set_location_assignment PIN_C4 -to HEX4[5]
+set_location_assignment PIN_C3 -to HEX4[6]
+set_location_assignment PIN_D3 -to HEX5[0]
+set_location_assignment PIN_A10 -to HEX5[1]
+set_location_assignment PIN_A9 -to HEX5[2]
+set_location_assignment PIN_A7 -to HEX5[3]
+set_location_assignment PIN_A6 -to HEX5[4]
+set_location_assignment PIN_A11 -to HEX5[5]
+set_location_assignment PIN_B6 -to HEX5[6]
+set_location_assignment PIN_B9 -to HEX6[0]
+set_location_assignment PIN_B10 -to HEX6[1]
+set_location_assignment PIN_C8 -to HEX6[2]
+set_location_assignment PIN_C9 -to HEX6[3]
+set_location_assignment PIN_D8 -to HEX6[4]
+set_location_assignment PIN_D9 -to HEX6[5]
+set_location_assignment PIN_E9 -to HEX6[6]
+set_location_assignment PIN_E10 -to HEX7[0]
+set_location_assignment PIN_F8 -to HEX7[1]
+set_location_assignment PIN_F9 -to HEX7[2]
+set_location_assignment PIN_C10 -to HEX7[3]
+set_location_assignment PIN_C11 -to HEX7[4]
+set_location_assignment PIN_C12 -to HEX7[5]
+set_location_assignment PIN_D12 -to HEX7[6]
+set_location_assignment PIN_K15 -to HSMC_CLKIN0
+set_location_assignment PIN_V30 -to HSMC_CLKIN_N1
+set_location_assignment PIN_T30 -to HSMC_CLKIN_N2
+set_location_assignment PIN_V29 -to HSMC_CLKIN_P1
+set_location_assignment PIN_T29 -to HSMC_CLKIN_P2
+set_location_assignment PIN_G6 -to HSMC_CLKOUT0
+set_location_assignment PIN_AB28 -to HSMC_CLKOUT_N1
+set_location_assignment PIN_Y28 -to HSMC_CLKOUT_N2
+set_location_assignment PIN_AB27 -to HSMC_CLKOUT_P1
+set_location_assignment PIN_AA28 -to HSMC_CLKOUT_P2
+set_location_assignment PIN_AC25 -to HSMC_D[0]
+set_location_assignment PIN_E27 -to HSMC_D[1]
+set_location_assignment PIN_AB26 -to HSMC_D[2]
+set_location_assignment PIN_E28 -to HSMC_D[3]
+set_location_assignment PIN_AD26 -to HSMC_I2C_SCLK
+set_location_assignment PIN_AD25 -to HSMC_I2C_SDAT
+set_location_assignment PIN_G27 -to HSMC_RX_D_N[0]
+set_location_assignment PIN_G29 -to HSMC_RX_D_N[1]
+set_location_assignment PIN_H27 -to HSMC_RX_D_N[2]
+set_location_assignment PIN_K29 -to HSMC_RX_D_N[3]
+set_location_assignment PIN_L28 -to HSMC_RX_D_N[4]
+set_location_assignment PIN_M28 -to HSMC_RX_D_N[5]
+set_location_assignment PIN_N30 -to HSMC_RX_D_N[6]
+set_location_assignment PIN_P28 -to HSMC_RX_D_N[7]
+set_location_assignment PIN_R28 -to HSMC_RX_D_N[8]
+set_location_assignment PIN_U28 -to HSMC_RX_D_N[9]
+set_location_assignment PIN_W28 -to HSMC_RX_D_N[10]
+set_location_assignment PIN_W30 -to HSMC_RX_D_N[11]
+set_location_assignment PIN_M30 -to HSMC_RX_D_N[12]
+set_location_assignment PIN_Y27 -to HSMC_RX_D_N[13]
+set_location_assignment PIN_AA29 -to HSMC_RX_D_N[14]
+set_location_assignment PIN_AD28 -to HSMC_RX_D_N[15]
+set_location_assignment PIN_AE28 -to HSMC_RX_D_N[16]
+set_location_assignment PIN_G26 -to HSMC_RX_D_P[0]
+set_location_assignment PIN_G28 -to HSMC_RX_D_P[1]
+set_location_assignment PIN_J27 -to HSMC_RX_D_P[2]
+set_location_assignment PIN_K28 -to HSMC_RX_D_P[3]
+set_location_assignment PIN_L27 -to HSMC_RX_D_P[4]
+set_location_assignment PIN_M27 -to HSMC_RX_D_P[5]
+set_location_assignment PIN_N29 -to HSMC_RX_D_P[6]
+set_location_assignment PIN_P27 -to HSMC_RX_D_P[7]
+set_location_assignment PIN_R27 -to HSMC_RX_D_P[8]
+set_location_assignment PIN_U27 -to HSMC_RX_D_P[9]
+set_location_assignment PIN_W27 -to HSMC_RX_D_P[10]
+set_location_assignment PIN_W29 -to HSMC_RX_D_P[11]
+set_location_assignment PIN_M29 -to HSMC_RX_D_P[12]
+set_location_assignment PIN_AA27 -to HSMC_RX_D_P[13]
+set_location_assignment PIN_AB29 -to HSMC_RX_D_P[14]
+set_location_assignment PIN_AD27 -to HSMC_RX_D_P[15]
+set_location_assignment PIN_AE27 -to HSMC_RX_D_P[16]
+set_location_assignment PIN_H28 -to HSMC_TX_D_N[0]
+set_location_assignment PIN_F29 -to HSMC_TX_D_N[1]
+set_location_assignment PIN_D30 -to HSMC_TX_D_N[2]
+set_location_assignment PIN_E30 -to HSMC_TX_D_N[3]
+set_location_assignment PIN_G30 -to HSMC_TX_D_N[4]
+set_location_assignment PIN_J30 -to HSMC_TX_D_N[5]
+set_location_assignment PIN_K27 -to HSMC_TX_D_N[6]
+set_location_assignment PIN_K30 -to HSMC_TX_D_N[7]
+set_location_assignment PIN_T25 -to HSMC_TX_D_N[8]
+set_location_assignment PIN_N28 -to HSMC_TX_D_N[9]
+set_location_assignment PIN_V26 -to HSMC_TX_D_N[10]
+set_location_assignment PIN_Y30 -to HSMC_TX_D_N[11]
+set_location_assignment PIN_AC28 -to HSMC_TX_D_N[12]
+set_location_assignment PIN_AD30 -to HSMC_TX_D_N[13]
+set_location_assignment PIN_AE30 -to HSMC_TX_D_N[14]
+set_location_assignment PIN_AH30 -to HSMC_TX_D_N[15]
+set_location_assignment PIN_AG29 -to HSMC_TX_D_N[16]
+set_location_assignment PIN_J28 -to HSMC_TX_D_P[0]
+set_location_assignment PIN_F28 -to HSMC_TX_D_P[1]
+set_location_assignment PIN_D29 -to HSMC_TX_D_P[2]
+set_location_assignment PIN_F30 -to HSMC_TX_D_P[3]
+set_location_assignment PIN_H30 -to HSMC_TX_D_P[4]
+set_location_assignment PIN_J29 -to HSMC_TX_D_P[5]
+set_location_assignment PIN_K26 -to HSMC_TX_D_P[6]
+set_location_assignment PIN_L30 -to HSMC_TX_D_P[7]
+set_location_assignment PIN_U25 -to HSMC_TX_D_P[8]
+set_location_assignment PIN_N27 -to HSMC_TX_D_P[9]
+set_location_assignment PIN_V25 -to HSMC_TX_D_P[10]
+set_location_assignment PIN_AA30 -to HSMC_TX_D_P[11]
+set_location_assignment PIN_AC27 -to HSMC_TX_D_P[12]
+set_location_assignment PIN_AD29 -to HSMC_TX_D_P[13]
+set_location_assignment PIN_AE29 -to HSMC_TX_D_P[14]
+set_location_assignment PIN_AJ30 -to HSMC_TX_D_P[15]
+set_location_assignment PIN_AH29 -to HSMC_TX_D_P[16]
+set_location_assignment PIN_C27 -to I2C_SCLK
+set_location_assignment PIN_G21 -to I2C_SDAT
+set_location_assignment PIN_AH28 -to IRDA_RXD
+set_location_assignment PIN_AA26 -to KEY[0]
+set_location_assignment PIN_AE25 -to KEY[1]
+set_location_assignment PIN_AF30 -to KEY[2]
+set_location_assignment PIN_AE26 -to KEY[3]
+set_location_assignment PIN_AG4 -to LCD_DATA[0]
+set_location_assignment PIN_AF3 -to LCD_DATA[1]
+set_location_assignment PIN_AH3 -to LCD_DATA[2]
+set_location_assignment PIN_AE5 -to LCD_DATA[3]
+set_location_assignment PIN_AH2 -to LCD_DATA[4]
+set_location_assignment PIN_AE3 -to LCD_DATA[5]
+set_location_assignment PIN_AH4 -to LCD_DATA[6]
+set_location_assignment PIN_AE4 -to LCD_DATA[7]
+set_location_assignment PIN_AF4 -to LCD_EN
+set_location_assignment PIN_AF27 -to LCD_ON
+set_location_assignment PIN_AG3 -to LCD_RS
+set_location_assignment PIN_AJ3 -to LCD_RW
+set_location_assignment PIN_AA25 -to LEDG[0]
+set_location_assignment PIN_AB25 -to LEDG[1]
+set_location_assignment PIN_F27 -to LEDG[2]
+set_location_assignment PIN_F26 -to LEDG[3]
+set_location_assignment PIN_W26 -to LEDG[4]
+set_location_assignment PIN_Y22 -to LEDG[5]
+set_location_assignment PIN_Y25 -to LEDG[6]
+set_location_assignment PIN_AA22 -to LEDG[7]
+set_location_assignment PIN_J25 -to LEDG[8]
+set_location_assignment PIN_T23 -to LEDR[0]
+set_location_assignment PIN_T24 -to LEDR[1]
+set_location_assignment PIN_V27 -to LEDR[2]
+set_location_assignment PIN_W25 -to LEDR[3]
+set_location_assignment PIN_T21 -to LEDR[4]
+set_location_assignment PIN_T26 -to LEDR[5]
+set_location_assignment PIN_R25 -to LEDR[6]
+set_location_assignment PIN_T27 -to LEDR[7]
+set_location_assignment PIN_P25 -to LEDR[8]
+set_location_assignment PIN_R24 -to LEDR[9]
+set_location_assignment PIN_P21 -to LEDR[10]
+set_location_assignment PIN_N24 -to LEDR[11]
+set_location_assignment PIN_N21 -to LEDR[12]
+set_location_assignment PIN_M25 -to LEDR[13]
+set_location_assignment PIN_K24 -to LEDR[14]
+set_location_assignment PIN_L25 -to LEDR[15]
+set_location_assignment PIN_M21 -to LEDR[16]
+set_location_assignment PIN_M22 -to LEDR[17]
+set_location_assignment PIN_A4 -to PCIE_PERST_N
+set_location_assignment PIN_V15 -to PCIE_REFCLK_P
+set_location_assignment PIN_AC2 -to PCIE_RX_P[0]
+set_location_assignment PIN_AA2 -to PCIE_RX_P[1]
+set_location_assignment PIN_AB4 -to PCIE_TX_P[0]
+set_location_assignment PIN_Y4 -to PCIE_TX_P[1]
+set_location_assignment PIN_C29 -to PCIE_WAKE_N
+set_location_assignment PIN_AH25 -to SD_CLK
+set_location_assignment PIN_AF18 -to SD_CMD
+set_location_assignment PIN_AH27 -to SD_DAT[0]
+set_location_assignment PIN_AJ28 -to SD_DAT[1]
+set_location_assignment PIN_AD24 -to SD_DAT[2]
+set_location_assignment PIN_AE18 -to SD_DAT[3]
+set_location_assignment PIN_AJ27 -to SD_WP_N
+set_location_assignment PIN_AK16 -to SMA_CLKIN
+set_location_assignment PIN_AF25 -to SMA_CLKOUT
+set_location_assignment PIN_AJ21 -to SSRAM0_CE_N
+set_location_assignment PIN_AG23 -to SSRAM1_CE_N
+set_location_assignment PIN_AK25 -to SSRAM_ADSC_N
+set_location_assignment PIN_AJ25 -to SSRAM_ADSP_N
+set_location_assignment PIN_AH26 -to SSRAM_ADV_N
+set_location_assignment PIN_AF22 -to SSRAM_BE[0]
+set_location_assignment PIN_AK22 -to SSRAM_BE[1]
+set_location_assignment PIN_AJ22 -to SSRAM_BE[2]
+set_location_assignment PIN_AF21 -to SSRAM_BE[3]
+set_location_assignment PIN_AF24 -to SSRAM_CLK
+set_location_assignment PIN_AK23 -to SSRAM_GW_N
+set_location_assignment PIN_AG24 -to SSRAM_OE_N
+set_location_assignment PIN_AK24 -to SSRAM_WE_N
+set_location_assignment PIN_V28 -to SW[0]
+set_location_assignment PIN_U30 -to SW[1]
+set_location_assignment PIN_V21 -to SW[2]
+set_location_assignment PIN_C2 -to SW[3]
+set_location_assignment PIN_AB30 -to SW[4]
+set_location_assignment PIN_U21 -to SW[5]
+set_location_assignment PIN_T28 -to SW[6]
+set_location_assignment PIN_R30 -to SW[7]
+set_location_assignment PIN_P30 -to SW[8]
+set_location_assignment PIN_R29 -to SW[9]
+set_location_assignment PIN_R26 -to SW[10]
+set_location_assignment PIN_N26 -to SW[11]
+set_location_assignment PIN_M26 -to SW[12]
+set_location_assignment PIN_N25 -to SW[13]
+set_location_assignment PIN_J26 -to SW[14]
+set_location_assignment PIN_K25 -to SW[15]
+set_location_assignment PIN_C30 -to SW[16]
+set_location_assignment PIN_H25 -to SW[17]
+set_location_assignment PIN_B15 -to TD_CLK27
+set_location_assignment PIN_C17 -to TD_DATA[0]
+set_location_assignment PIN_D17 -to TD_DATA[1]
+set_location_assignment PIN_A16 -to TD_DATA[2]
+set_location_assignment PIN_B16 -to TD_DATA[3]
+set_location_assignment PIN_G18 -to TD_DATA[4]
+set_location_assignment PIN_G17 -to TD_DATA[5]
+set_location_assignment PIN_K18 -to TD_DATA[6]
+set_location_assignment PIN_K17 -to TD_DATA[7]
+set_location_assignment PIN_C28 -to TD_HS
+set_location_assignment PIN_E25 -to TD_RESET_N
+set_location_assignment PIN_E22 -to TD_VS
+set_location_assignment PIN_D26 -to UART_CTS
+set_location_assignment PIN_A29 -to UART_RTS
+set_location_assignment PIN_B27 -to UART_RXD
+set_location_assignment PIN_H24 -to UART_TXD
+set_location_assignment PIN_E24 -to VGA_B[0]
+set_location_assignment PIN_C24 -to VGA_B[1]
+set_location_assignment PIN_B25 -to VGA_B[2]
+set_location_assignment PIN_C23 -to VGA_B[3]
+set_location_assignment PIN_F24 -to VGA_B[4]
+set_location_assignment PIN_A23 -to VGA_B[5]
+set_location_assignment PIN_G25 -to VGA_B[6]
+set_location_assignment PIN_C22 -to VGA_B[7]
+set_location_assignment PIN_F25 -to VGA_BLANK_N
+set_location_assignment PIN_D27 -to VGA_CLK
+set_location_assignment PIN_D20 -to VGA_G[0]
+set_location_assignment PIN_C20 -to VGA_G[1]
+set_location_assignment PIN_A20 -to VGA_G[2]
+set_location_assignment PIN_K19 -to VGA_G[3]
+set_location_assignment PIN_A21 -to VGA_G[4]
+set_location_assignment PIN_F21 -to VGA_G[5]
+set_location_assignment PIN_A22 -to VGA_G[6]
+set_location_assignment PIN_B22 -to VGA_G[7]
+set_location_assignment PIN_B24 -to VGA_HS
+set_location_assignment PIN_A17 -to VGA_R[0]
+set_location_assignment PIN_C18 -to VGA_R[1]
+set_location_assignment PIN_B18 -to VGA_R[2]
+set_location_assignment PIN_A18 -to VGA_R[3]
+set_location_assignment PIN_E18 -to VGA_R[4]
+set_location_assignment PIN_E19 -to VGA_R[5]
+set_location_assignment PIN_B19 -to VGA_R[6]
+set_location_assignment PIN_C19 -to VGA_R[7]
+set_location_assignment PIN_AH20 -to VGA_SYNC_N
+set_location_assignment PIN_A24 -to VGA_VS
+set_instance_assignment -name VIRTUAL_PIN ON -to FS_ADDR[0]
+#============================================================
+set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
+set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
+set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
+set_global_assignment -name STRATIX_DEVICE_IO_STANDARD "2.5 V"
+set_global_assignment -name VQM_FILE ../top.vqm
+set_global_assignment -name SDC_FILE de2i_150_golden_top.sdc
+set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
+set_global_assignment -name MAX_CORE_JUNCTION_TEMP 85
+set_global_assignment -name POWER_PRESET_COOLING_SOLUTION "23 MM HEAT SINK WITH 200 LFPM AIRFLOW"
+set_global_assignment -name POWER_BOARD_THERMAL_MODEL "NONE (CONSERVATIVE)"
+set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top

--- a/examples/intel/DE2i-150/quartus_compile/runme_quartus
+++ b/examples/intel/DE2i-150/quartus_compile/runme_quartus
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export REV="de2i"
+
+quartus_map -c $REV top && \
+    quartus_fit -c $REV top && \
+	    quartus_asm -c $REV top

--- a/examples/intel/DE2i-150/run_cycloneiv
+++ b/examples/intel/DE2i-150/run_cycloneiv
@@ -1,0 +1,2 @@
+#/bin/env bash
+yosys -p "synth_intel -family cycloneiv -top top -vout top.vqm" top.v sevenseg.v

--- a/examples/intel/DE2i-150/sevenseg.v
+++ b/examples/intel/DE2i-150/sevenseg.v
@@ -1,0 +1,25 @@
+module sevenseg ( output reg [6:0] HEX0,
+                  input      [3:0] SW );
+
+   always @(*) begin
+     case(SW)
+        4'h1: HEX0 = 7'b1111001;	
+	4'h2: HEX0 = 7'b0100100; 	
+	4'h3: HEX0 = 7'b0110000; 	
+	4'h4: HEX0 = 7'b0011001; 	
+	4'h5: HEX0 = 7'b0010010; 	
+	4'h6: HEX0 = 7'b0000010; 	
+	4'h7: HEX0 = 7'b1111000; 	
+	4'h8: HEX0 = 7'b0000000; 	
+	4'h9: HEX0 = 7'b0011000; 	
+	4'ha: HEX0 = 7'b0001000;
+	4'hb: HEX0 = 7'b0000011;
+	4'hc: HEX0 = 7'b1000110;
+	4'hd: HEX0 = 7'b0100001;
+	4'he: HEX0 = 7'b0000110;
+	4'hf: HEX0 = 7'b0001110;
+	4'h0: HEX0 = 7'b1000000;
+     endcase // case (SW)
+   end 
+   
+endmodule

--- a/examples/intel/DE2i-150/top.v
+++ b/examples/intel/DE2i-150/top.v
@@ -1,0 +1,15 @@
+`default_nettype none
+module top ( output wire [6:0] HEX0, HEX1, HEX2, HEX3, HEX4, HEX5, HEX6, HEX7,
+             input  wire [15:0] SW );
+             
+  
+    sevenseg UUD0 (.HEX0(HEX0), .SW(4'h7));
+    sevenseg UUD1 (.HEX0(HEX1), .SW(4'h1));
+    sevenseg UUD2 (.HEX0(HEX2), .SW(4'h0));
+    sevenseg UUD3 (.HEX0(HEX3), .SW(4'h2));
+    sevenseg UUD4 (.HEX0(HEX4), .SW(SW[3:0]));
+    sevenseg UUD5 (.HEX0(HEX5), .SW(SW[7:4]));
+    sevenseg UUD6 (.HEX0(HEX6), .SW(SW[11:8]));
+    sevenseg UUD7 (.HEX0(HEX7), .SW(SW[15:12]));
+    
+endmodule

--- a/examples/intel/MAX10/run_max10
+++ b/examples/intel/MAX10/run_max10
@@ -1,0 +1,1 @@
+yosys -p "synth_intel -family max10 -top top -vout top.vqm" top.v sevenseg.v

--- a/examples/intel/MAX10/runme_postsynth
+++ b/examples/intel/MAX10/runme_postsynth
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+iverilog -D POST_IMPL -o verif_post -s tb_top tb_top.v top.vqm $(yosys-config --datdir/altera_intel/max10/cells_comb_max10.v)
+vvp -N verif_post
+

--- a/examples/intel/MAX10/sevenseg.v
+++ b/examples/intel/MAX10/sevenseg.v
@@ -1,0 +1,25 @@
+module sevenseg ( output reg [6:0] HEX0,
+                  input      [3:0] SW );
+
+   always @(*) begin
+     case(SW)
+        4'h1: HEX0 = 7'b1111001;	
+	4'h2: HEX0 = 7'b0100100; 	
+	4'h3: HEX0 = 7'b0110000; 	
+	4'h4: HEX0 = 7'b0011001; 	
+	4'h5: HEX0 = 7'b0010010; 	
+	4'h6: HEX0 = 7'b0000010; 	
+	4'h7: HEX0 = 7'b1111000; 	
+	4'h8: HEX0 = 7'b0000000; 	
+	4'h9: HEX0 = 7'b0011000; 	
+	4'ha: HEX0 = 7'b0001000;
+	4'hb: HEX0 = 7'b0000011;
+	4'hc: HEX0 = 7'b1000110;
+	4'hd: HEX0 = 7'b0100001;
+	4'he: HEX0 = 7'b0000110;
+	4'hf: HEX0 = 7'b0001110;
+	4'h0: HEX0 = 7'b1000000;
+     endcase // case (SW)
+   end 
+   
+endmodule

--- a/examples/intel/MAX10/top.v
+++ b/examples/intel/MAX10/top.v
@@ -1,0 +1,15 @@
+`default_nettype none
+module top ( output wire [6:0] HEX0, HEX1, HEX2, HEX3, HEX4, HEX5, HEX6, HEX7,
+             input  wire [15:0] SW );
+             
+  
+    sevenseg UUD0 (.HEX0(HEX0), .SW(4'h7));
+    sevenseg UUD1 (.HEX0(HEX1), .SW(4'h1));
+    sevenseg UUD2 (.HEX0(HEX2), .SW(4'h0));
+    sevenseg UUD3 (.HEX0(HEX3), .SW(4'h2));
+    sevenseg UUD4 (.HEX0(HEX4), .SW(SW[3:0]));
+    sevenseg UUD5 (.HEX0(HEX5), .SW(SW[7:4]));
+    sevenseg UUD6 (.HEX0(HEX6), .SW(SW[11:8]));
+    sevenseg UUD7 (.HEX0(HEX7), .SW(SW[15:12]));
+    
+endmodule

--- a/examples/intel/asicworld_lfsr/README
+++ b/examples/intel/asicworld_lfsr/README
@@ -1,0 +1,6 @@
+Source of the files:
+http://www.asic-world.com/examples/verilog/lfsr.html
+
+Run first: runme_presynth
+Generate output netlist with run_max10 or run_cycloneiv
+Then, check with: runme_postsynth

--- a/examples/intel/asicworld_lfsr/lfsr_updown.v
+++ b/examples/intel/asicworld_lfsr/lfsr_updown.v
@@ -1,0 +1,35 @@
+`default_nettype none
+module lfsr_updown (
+clk       ,   // Clock input
+reset     ,   // Reset input
+enable    ,   // Enable input
+up_down   ,   // Up Down input
+count     ,   // Count output
+overflow      // Overflow output
+);
+
+ input clk;
+ input reset;
+ input enable; 
+ input up_down;
+
+ output [7 : 0] count;
+ output overflow;
+
+ reg [7 : 0] count;
+
+ assign overflow = (up_down) ? (count == {{7{1'b0}}, 1'b1}) : 
+                               (count == {1'b1, {7{1'b0}}}) ;
+
+ always @(posedge clk)
+ if (reset) 
+    count <= {7{1'b0}};
+ else if (enable) begin
+    if (up_down) begin
+      count <= {~(^(count & 8'b01100011)),count[7:1]};
+    end else begin
+      count <= {count[5:0],~(^(count &  8'b10110001))};
+    end
+ end
+
+endmodule

--- a/examples/intel/asicworld_lfsr/lfsr_updown_tb.v
+++ b/examples/intel/asicworld_lfsr/lfsr_updown_tb.v
@@ -1,0 +1,34 @@
+module tb();
+ reg clk;
+ reg reset;
+ reg enable;
+ reg up_down;
+
+ wire [7 : 0] count;
+ wire overflow;
+
+initial begin
+  $monitor("rst %b en %b updown %b cnt %b overflow %b",
+     reset,enable,up_down,count, overflow);
+  clk = 0;
+  reset = 1;
+  enable = 0;
+  up_down = 0;
+  #10 reset = 0;
+  #1 enable = 1;
+  #20 up_down = 1;
+  #30 $finish;
+end
+
+always #1 clk = ~clk;
+
+lfsr_updown U(
+.clk      ( clk      ),
+.reset    ( reset    ),
+.enable   ( enable   ),
+.up_down  ( up_down  ),
+.count    ( count    ),
+.overflow ( overflow )
+);
+
+endmodule 

--- a/examples/intel/asicworld_lfsr/run_cycloneiv
+++ b/examples/intel/asicworld_lfsr/run_cycloneiv
@@ -1,0 +1,2 @@
+#!/bin/env bash
+yosys -p "synth_intel -family cycloneiv -top lfsr_updown -vout top.vqm" lfsr_updown.v

--- a/examples/intel/asicworld_lfsr/run_max10
+++ b/examples/intel/asicworld_lfsr/run_max10
@@ -1,0 +1,2 @@
+#!/bin/env bash
+yosys -p "synth_intel -family max10 -top lfsr_updown -vout top.vqm" lfsr_updown.v

--- a/examples/intel/asicworld_lfsr/runme_postsynth
+++ b/examples/intel/asicworld_lfsr/runme_postsynth
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+iverilog -D POST_IMPL -o verif_post -s tb lfsr_updown_tb.v top.vqm $(yosys-config --datdir/altera_intel/max10/cells_comb_max10.v)
+vvp -N verif_post
+

--- a/examples/intel/asicworld_lfsr/runme_presynth
+++ b/examples/intel/asicworld_lfsr/runme_presynth
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+iverilog -o presynth lfsr_updown_tb.v lfsr_updown.v &&\
+
+vvp -N presynth

--- a/techlibs/altera_intel/Makefile.inc
+++ b/techlibs/altera_intel/Makefile.inc
@@ -1,0 +1,10 @@
+
+OBJS += techlibs/altera_intel/synth_intel.o
+
+#$(eval $(call add_share_file,share/altera_intel,techlibs/altera_intel/lpm_functions.v))
+$(eval $(call add_share_file,share/altera_intel/max10,techlibs/altera_intel/max10/cells_comb_max10.v))
+$(eval $(call add_share_file,share/altera_intel/cycloneiv,techlibs/altera_intel/cycloneiv/cells_comb_cycloneiv.v))
+$(eval $(call add_share_file,share/altera_intel/max10,techlibs/altera_intel/max10/cells_map_max10.v))
+$(eval $(call add_share_file,share/altera_intel/cycloneiv,techlibs/altera_intel/cycloneiv/cells_map_cycloneiv.v))
+#$(eval $(call add_share_file,share/altera_intel/max10,techlibs/altera_intel/max10/cells_arith_max10.v))
+

--- a/techlibs/altera_intel/cycloneiv/cells_comb_cycloneiv.v
+++ b/techlibs/altera_intel/cycloneiv/cells_comb_cycloneiv.v
@@ -1,0 +1,128 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+ 
+module VCC (output V);
+   assign V = 1'b1;
+endmodule // VCC
+
+module GND (output G);
+   assign G = 1'b0;
+endmodule // GND
+
+/* Altera Cyclone IV (GX) devices Input Buffer Primitive */
+module cycloneiv_io_ibuf (output o, input i, input ibar);
+   assign ibar = ibar;
+   assign o    = i;
+endmodule // fiftyfivenm_io_ibuf
+
+/* Altera Cyclone IV (GX)  devices Output Buffer Primitive */
+module cycloneiv_io_obuf (output o, input i, input oe);
+   assign o  = i;
+   assign oe = oe;
+endmodule // fiftyfivenm_io_obuf
+
+/* Altera MAX10 4-input non-fracturable LUT Primitive */ 
+module cycloneiv_lcell_comb (output combout, cout,
+                             input dataa, datab, datac, datad, cin);
+
+/* Internal parameters which define the behaviour
+   of the LUT primitive.
+   lut_mask define the lut function, can be expressed in 16-digit bin or hex.
+   sum_lutc_input define the type of LUT (combinational | arithmetic). 
+   dont_touch for retiming || carry options.
+   lpm_type for WYSIWYG */  
+   
+parameter lut_mask = 16'hFFFF;
+parameter dont_touch = "off";
+parameter lpm_type = "cycloneiv_lcell_comb";
+parameter sum_lutc_input = "datac";
+  
+reg [1:0] lut_type;  
+reg cout_rt;
+reg combout_rt;
+wire dataa_w;
+wire datab_w;
+wire datac_w;
+wire datad_w;
+wire cin_w;
+
+assign dataa_w = dataa;
+assign datab_w = datab;
+assign datac_w = datac;
+assign datad_w = datad;
+
+function lut_data;
+input [15:0] mask;
+input        dataa, datab, datac, datad;
+reg [7:0]   s3;
+reg [3:0]   s2;
+reg [1:0]   s1;
+  begin
+       s3 = datad ? mask[15:8] : mask[7:0];
+       s2 = datac ?   s3[7:4]  :   s3[3:0];
+       s1 = datab ?   s2[3:2]  :   s2[1:0];
+       lut_data = dataa ? s1[1] : s1[0];
+  end
+
+endfunction
+
+initial begin
+    if (sum_lutc_input == "datac") lut_type = 0;
+    else 
+    if (sum_lutc_input == "cin")   lut_type = 1;
+    else begin
+      $error("Error in sum_lutc_input. Parameter %s is not a valid value.\n", sum_lutc_input);
+      $finish();
+    end
+end
+
+always @(dataa_w or datab_w or datac_w or datad_w or cin_w) begin
+    if (lut_type == 0) begin // logic function
+        combout_rt = lut_data(lut_mask, dataa_w, datab_w, 
+                            datac_w, datad_w);
+    end
+    else if (lut_type == 1) begin // arithmetic function
+        combout_rt = lut_data(lut_mask, dataa_w, datab_w, 
+                            cin_w, datad_w);
+    end
+    cout_rt = lut_data(lut_mask, dataa_w, datab_w, cin_w, 'b0);
+end
+
+assign combout = combout_rt & 1'b1;
+assign cout = cout_rt & 1'b1;
+
+endmodule // cycloneiv_lcell_comb
+
+/* Altera Cyclone IV Flip-Flop Primitive */
+// TODO: Implement advanced simulation functions
+module dffeas ( output q, 
+                input d, clk, clrn, prn, ena, 
+		input asdata, aload, sclr, sload );
+  								     
+parameter power_up="dontcare";
+parameter is_wysiwyg="false";
+  reg q;
+
+  always @(posedge clk)
+    q <= d;
+   
+endmodule
+
+
+

--- a/techlibs/altera_intel/cycloneiv/cells_map_cycloneiv.v
+++ b/techlibs/altera_intel/cycloneiv/cells_map_cycloneiv.v
@@ -1,0 +1,61 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+ 
+// Flip-flop D
+module  \$_DFF_P_ (input D, input C, output Q);
+   parameter WYSIWYG="TRUE";
+   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+endmodule //
+
+// Input buffer map
+module \$__inpad (input I, output O);
+    cycloneiv_io_ibuf _TECHMAP_REPLACE_ (.o(O), .i(I), .ibar(1'b0));
+endmodule 
+
+// Output buffer map   
+module \$__outpad (input I, output O);
+    cycloneiv_io_obuf _TECHMAP_REPLACE_ (.o(O), .i(I), .oe(1'b1));
+endmodule 
+
+// LUT Map
+/* 0 -> datac
+   1 -> cin */
+module \$lut (A, Y);
+   parameter WIDTH  = 0;
+   parameter LUT    = 0;
+   input [WIDTH-1:0] A;
+   output 	     Y;
+   generate 
+      if (WIDTH == 1) begin
+	   assign Y = ~A[0]; // Not need to spend 1 logic cell for such an easy function
+      end else
+      if (WIDTH == 2) begin
+           cycloneiv_lcell_comb #(.lut_mask({4{LUT}}), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(1'b1),.datad(1'b1));
+      end else
+      if(WIDTH == 3) begin 
+	   cycloneiv_lcell_comb #(.lut_mask({2{LUT}}), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(A[2]),.datad(1'b1));
+      end else
+      if(WIDTH == 4) begin
+	   cycloneiv_lcell_comb #(.lut_mask(LUT), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(A[2]),.datad(A[3]));
+      end else
+	   wire _TECHMAP_FAIL_ = 1;
+   endgenerate
+endmodule //
+
+	    

--- a/techlibs/altera_intel/lpm_functions.v
+++ b/techlibs/altera_intel/lpm_functions.v
@@ -1,0 +1,319 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+ 
+// NOTE: This is still WIP.
+(* techmap_celltype = "$altpll" *)
+module _80_altpll_altera  ( input [1:0] inclk, 
+			    input       fbin, 
+			    input       pllena, 
+			    input       clkswitch, 
+			    input       areset, 
+			    input       pfdena, 
+			    input       clkena, 
+			    input       extclkena, 
+			    input       scanclk, 
+			    input 	scanaclr, 
+			    input       scanclkena, 
+			    input       scanread, 
+			    input       scanwrite, 
+			    input       scandata, 
+			    input       phasecounterselect, 
+			    input       phaseupdown,
+			    input       phasestep,
+			    input       configupdate,
+			    inout       fbmimicbidir,
+			    
+			    output [width_clock-1:0] clk, 
+			    output [3:0]             extclk,     
+			    output [1:0]             clkbad,     
+			    output 	             enable0,     
+			    output 		     enable1,     
+			    output 		     activeclock, 
+			    output 		     clkloss,     
+			    output 		     locked,      
+			    output 		     scandataout, 
+			    output 		     scandone,    
+			    output 		     sclkout0,    
+			    output 		     sclkout1,    
+			    output 	             phasedone,
+			    output 		     vcooverrange,
+			    output 		     vcounderrange,
+			    output 		     fbout,
+			    output 		     fref,
+			    output 		     icdrclk );
+			    
+			    parameter   intended_device_family    = "MAX 10";
+			    parameter   operation_mode            = "NORMAL";
+			    parameter   pll_type                  = "AUTO";
+			    parameter   qualify_conf_done         = "OFF";
+			    parameter   compensate_clock          = "CLK0";
+			    parameter   scan_chain                = "LONG";
+			    parameter   primary_clock             = "inclk0";
+			    parameter   inclk0_input_frequency    = 1000;
+			    parameter   inclk1_input_frequency    = 0;
+			    parameter   gate_lock_signal          = "NO";
+			    parameter   gate_lock_counter         = 0;
+			    parameter   lock_high                 = 1;
+			    parameter   lock_low                  = 0;
+			    parameter   valid_lock_multiplier     = 1;
+			    parameter   invalid_lock_multiplier   = 5;
+			    parameter   switch_over_type          = "AUTO";
+			    parameter   switch_over_on_lossclk    = "OFF" ;
+			    parameter   switch_over_on_gated_lock = "OFF" ;
+			    parameter   enable_switch_over_counter = "OFF";
+			    parameter   switch_over_counter       = 0;
+			    parameter   feedback_source           = "EXTCLK0" ;
+			    parameter   bandwidth                 = 0;
+			    parameter   bandwidth_type            = "UNUSED";
+			    parameter   lpm_hint                  = "UNUSED";
+			    parameter   spread_frequency          = 0;
+			    parameter   down_spread               = "0.0";
+			    parameter   self_reset_on_gated_loss_lock = "OFF";
+			    parameter   self_reset_on_loss_lock = "OFF";
+			    parameter   lock_window_ui           = "0.05";
+			    parameter   width_clock              = 6;
+			    parameter   width_phasecounterselect = 4;
+			    parameter   charge_pump_current_bits = 9999;
+			    parameter   loop_filter_c_bits = 9999;
+			    parameter   loop_filter_r_bits = 9999;
+			    parameter   scan_chain_mif_file = "UNUSED";
+			    parameter   clk9_multiply_by        = 1;
+			    parameter   clk8_multiply_by        = 1;
+			    parameter   clk7_multiply_by        = 1;
+			    parameter   clk6_multiply_by        = 1;
+			    parameter   clk5_multiply_by        = 1;
+			    parameter   clk4_multiply_by        = 1;
+			    parameter   clk3_multiply_by        = 1;
+			    parameter   clk2_multiply_by        = 1;
+			    parameter   clk1_multiply_by        = 1;
+			    parameter   clk0_multiply_by        = 1;
+			    parameter   clk9_divide_by          = 1;
+			    parameter   clk8_divide_by          = 1;
+			    parameter   clk7_divide_by          = 1;
+			    parameter   clk6_divide_by          = 1;
+			    parameter   clk5_divide_by          = 1;
+			    parameter   clk4_divide_by          = 1;
+			    parameter   clk3_divide_by          = 1;
+			    parameter   clk2_divide_by          = 1;
+			    parameter   clk1_divide_by          = 1;
+			    parameter   clk0_divide_by          = 1;
+			    parameter   clk9_phase_shift        = "0";
+			    parameter   clk8_phase_shift        = "0";
+			    parameter   clk7_phase_shift        = "0";
+			    parameter   clk6_phase_shift        = "0";
+			    parameter   clk5_phase_shift        = "0";
+			    parameter   clk4_phase_shift        = "0";
+			    parameter   clk3_phase_shift        = "0";
+			    parameter   clk2_phase_shift        = "0";
+			    parameter   clk1_phase_shift        = "0";
+			    parameter   clk0_phase_shift        = "0";
+			    
+			    parameter   clk9_duty_cycle         = 50;
+			    parameter   clk8_duty_cycle         = 50;
+			    parameter   clk7_duty_cycle         = 50;
+			    parameter   clk6_duty_cycle         = 50;
+			    parameter   clk5_duty_cycle         = 50;
+			    parameter   clk4_duty_cycle         = 50;
+			    parameter   clk3_duty_cycle         = 50;
+			    parameter   clk2_duty_cycle         = 50;
+			    parameter   clk1_duty_cycle         = 50;
+			    parameter   clk0_duty_cycle         = 50;
+
+			    parameter   clk9_use_even_counter_mode    = "OFF";
+			    parameter   clk8_use_even_counter_mode    = "OFF";
+			    parameter   clk7_use_even_counter_mode    = "OFF";
+			    parameter   clk6_use_even_counter_mode    = "OFF";
+			    parameter   clk5_use_even_counter_mode    = "OFF";
+			    parameter   clk4_use_even_counter_mode    = "OFF";
+			    parameter   clk3_use_even_counter_mode    = "OFF";
+			    parameter   clk2_use_even_counter_mode    = "OFF";
+			    parameter   clk1_use_even_counter_mode    = "OFF";
+			    parameter   clk0_use_even_counter_mode    = "OFF";
+			    parameter   clk9_use_even_counter_value   = "OFF";
+			    parameter   clk8_use_even_counter_value   = "OFF";
+			    parameter   clk7_use_even_counter_value   = "OFF";
+			    parameter   clk6_use_even_counter_value   = "OFF";
+			    parameter   clk5_use_even_counter_value   = "OFF";
+			    parameter   clk4_use_even_counter_value   = "OFF";
+			    parameter   clk3_use_even_counter_value   = "OFF";
+			    parameter   clk2_use_even_counter_value   = "OFF";
+			    parameter   clk1_use_even_counter_value   = "OFF";
+			    parameter   clk0_use_even_counter_value   = "OFF";
+
+			    parameter   clk2_output_frequency   = 0;
+			    parameter   clk1_output_frequency   = 0;
+			    parameter   clk0_output_frequency   = 0;
+
+			    parameter   vco_min             = 0;
+			    parameter   vco_max             = 0;
+			    parameter   vco_center          = 0;
+			    parameter   pfd_min             = 0;
+			    parameter   pfd_max             = 0;
+			    parameter   m_initial           = 1;
+			    parameter   m                   = 0; 
+			    parameter   n                   = 1;
+			    parameter   m2                  = 1;
+			    parameter   n2                  = 1;
+			    parameter   ss                  = 0;
+			    parameter   l0_high             = 1;
+			    parameter   l1_high             = 1;
+			    parameter   g0_high             = 1;
+			    parameter   g1_high             = 1;
+			    parameter   g2_high             = 1;
+			    parameter   g3_high             = 1;
+			    parameter   e0_high             = 1;
+			    parameter   e1_high             = 1;
+			    parameter   e2_high             = 1;
+			    parameter   e3_high             = 1;
+			    parameter   l0_low              = 1;
+			    parameter   l1_low              = 1;
+			    parameter   g0_low              = 1;
+			    parameter   g1_low              = 1;
+			    parameter   g2_low              = 1;
+			    parameter   g3_low              = 1;
+			    parameter   e0_low              = 1;
+			    parameter   e1_low              = 1;
+			    parameter   e2_low              = 1;
+			    parameter   e3_low              = 1;
+			    parameter   l0_initial          = 1;
+			    parameter   l1_initial          = 1;
+			    parameter   g0_initial          = 1;
+			    parameter   g1_initial          = 1;
+			    parameter   g2_initial          = 1;
+			    parameter   g3_initial          = 1;
+			    parameter   e0_initial          = 1;
+			    parameter   e1_initial          = 1;
+			    parameter   e2_initial          = 1;
+			    parameter   e3_initial          = 1;
+			    parameter   l0_mode             = "bypass";
+			    parameter   l1_mode             = "bypass";
+			    parameter   g0_mode             = "bypass";
+			    parameter   g1_mode             = "bypass";
+			    parameter   g2_mode             = "bypass";
+			    parameter   g3_mode             = "bypass";
+			    parameter   e0_mode             = "bypass";
+			    parameter   e1_mode             = "bypass";
+			    parameter   e2_mode             = "bypass";
+			    parameter   e3_mode             = "bypass";
+			    parameter   l0_ph               = 0;
+			    parameter   l1_ph               = 0;
+			    parameter   g0_ph               = 0;
+			    parameter   g1_ph               = 0;
+			    parameter   g2_ph               = 0;
+			    parameter   g3_ph               = 0;
+			    parameter   e0_ph               = 0;
+			    parameter   e1_ph               = 0;
+			    parameter   e2_ph               = 0;
+			    parameter   e3_ph               = 0;
+			    parameter   m_ph                = 0;
+			    parameter   l0_time_delay       = 0;
+			    parameter   l1_time_delay       = 0;
+			    parameter   g0_time_delay       = 0;
+			    parameter   g1_time_delay       = 0;
+			    parameter   g2_time_delay       = 0;
+			    parameter   g3_time_delay       = 0;
+			    parameter   e0_time_delay       = 0;
+			    parameter   e1_time_delay       = 0;
+			    parameter   e2_time_delay       = 0;
+			    parameter   e3_time_delay       = 0;
+			    parameter   m_time_delay        = 0;
+			    parameter   n_time_delay        = 0;
+			    parameter   extclk3_counter     = "e3" ;
+			    parameter   extclk2_counter     = "e2" ;
+			    parameter   extclk1_counter     = "e1" ;
+			    parameter   extclk0_counter     = "e0" ;
+			    parameter   clk9_counter        = "c9" ;
+			    parameter   clk8_counter        = "c8" ;
+			    parameter   clk7_counter        = "c7" ;
+			    parameter   clk6_counter        = "c6" ;
+			    parameter   clk5_counter        = "l1" ;
+			    parameter   clk4_counter        = "l0" ;
+			    parameter   clk3_counter        = "g3" ;
+			    parameter   clk2_counter        = "g2" ;
+			    parameter   clk1_counter        = "g1" ;
+			    parameter   clk0_counter        = "g0" ;
+			    parameter   enable0_counter     = "l0";
+			    parameter   enable1_counter     = "l0";
+			    parameter   charge_pump_current = 2;
+			    parameter   loop_filter_r       = "1.0";
+			    parameter   loop_filter_c       = 5;
+			    parameter   vco_post_scale      = 0;
+			    parameter   vco_frequency_control = "AUTO";
+			    parameter   vco_phase_shift_step = 0;
+			    parameter   lpm_type            = "altpll";
+
+			    parameter port_clkena0 = "PORT_CONNECTIVITY";
+			    parameter port_clkena1 = "PORT_CONNECTIVITY";
+			    parameter port_clkena2 = "PORT_CONNECTIVITY";
+			    parameter port_clkena3 = "PORT_CONNECTIVITY";
+			    parameter port_clkena4 = "PORT_CONNECTIVITY";
+			    parameter port_clkena5 = "PORT_CONNECTIVITY";
+			    parameter port_extclkena0 = "PORT_CONNECTIVITY";
+			    parameter port_extclkena1 = "PORT_CONNECTIVITY";
+			    parameter port_extclkena2 = "PORT_CONNECTIVITY";
+			    parameter port_extclkena3 = "PORT_CONNECTIVITY";
+			    parameter port_extclk0 = "PORT_CONNECTIVITY";
+			    parameter port_extclk1 = "PORT_CONNECTIVITY";
+			    parameter port_extclk2 = "PORT_CONNECTIVITY";
+			    parameter port_extclk3 = "PORT_CONNECTIVITY";
+			    parameter port_clk0 = "PORT_CONNECTIVITY";
+			    parameter port_clk1 = "PORT_CONNECTIVITY";
+			    parameter port_clk2 = "PORT_CONNECTIVITY";
+			    parameter port_clk3 = "PORT_CONNECTIVITY";
+			    parameter port_clk4 = "PORT_CONNECTIVITY";
+			    parameter port_clk5 = "PORT_CONNECTIVITY";
+			    parameter port_clk6 = "PORT_CONNECTIVITY";
+			    parameter port_clk7 = "PORT_CONNECTIVITY";
+			    parameter port_clk8 = "PORT_CONNECTIVITY";
+			    parameter port_clk9 = "PORT_CONNECTIVITY";
+			    parameter port_scandata = "PORT_CONNECTIVITY";
+			    parameter port_scandataout = "PORT_CONNECTIVITY";
+			    parameter port_scandone = "PORT_CONNECTIVITY";
+			    parameter port_sclkout1 = "PORT_CONNECTIVITY";
+			    parameter port_sclkout0 = "PORT_CONNECTIVITY";
+			    parameter port_clkbad0 = "PORT_CONNECTIVITY";
+			    parameter port_clkbad1 = "PORT_CONNECTIVITY";
+			    parameter port_activeclock = "PORT_CONNECTIVITY";
+			    parameter port_clkloss = "PORT_CONNECTIVITY";
+			    parameter port_inclk1 = "PORT_CONNECTIVITY";
+			    parameter port_inclk0 = "PORT_CONNECTIVITY";
+			    parameter port_fbin = "PORT_CONNECTIVITY";
+			    parameter port_fbout = "PORT_CONNECTIVITY";
+			    parameter port_pllena = "PORT_CONNECTIVITY";
+			    parameter port_clkswitch = "PORT_CONNECTIVITY";
+			    parameter port_areset = "PORT_CONNECTIVITY";
+			    parameter port_pfdena = "PORT_CONNECTIVITY";
+			    parameter port_scanclk = "PORT_CONNECTIVITY";
+			    parameter port_scanaclr = "PORT_CONNECTIVITY";
+			    parameter port_scanread = "PORT_CONNECTIVITY";
+			    parameter port_scanwrite = "PORT_CONNECTIVITY";
+			    parameter port_enable0 = "PORT_CONNECTIVITY";
+			    parameter port_enable1 = "PORT_CONNECTIVITY";
+			    parameter port_locked = "PORT_CONNECTIVITY";
+			    parameter port_configupdate = "PORT_CONNECTIVITY";
+			    parameter port_phasecounterselect = "PORT_CONNECTIVITY";
+			    parameter port_phasedone = "PORT_CONNECTIVITY";
+			    parameter port_phasestep = "PORT_CONNECTIVITY";
+			    parameter port_phaseupdown = "PORT_CONNECTIVITY";
+			    parameter port_vcooverrange = "PORT_CONNECTIVITY";
+			    parameter port_vcounderrange = "PORT_CONNECTIVITY";
+			    parameter port_scanclkena = "PORT_CONNECTIVITY";
+			    parameter using_fbmimicbidir_port = "ON";
+
+endmodule

--- a/techlibs/altera_intel/max10/cells_arith_max10.v
+++ b/techlibs/altera_intel/max10/cells_arith_max10.v
@@ -1,0 +1,62 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+// NOTE: This is still WIP.
+(* techmap_celltype = "$alu" *)
+module _80_altera_max10_alu (A, B, CI, BI, X, Y, CO);
+   parameter A_SIGNED = 0;
+   parameter B_SIGNED = 0;
+   parameter A_WIDTH  = 1;
+   parameter B_WIDTH  = 1;
+   parameter Y_WIDTH  = 1;
+   parameter LUT      = 0;
+   
+   input [A_WIDTH-1:0] A;
+   input [B_WIDTH-1:0] B;
+   output [Y_WIDTH-1:0] X, Y;
+
+   input 		CI, BI;
+   output [Y_WIDTH-1:0] CO;
+
+   wire 		_TECHMAP_FAIL_ = Y_WIDTH <= 2;
+
+   wire                 tempcombout;
+   wire [Y_WIDTH-1:0] 	A_buf, B_buf;
+   \$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
+   \$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+
+   wire [Y_WIDTH-1:0] AA = A_buf;
+   wire [Y_WIDTH-1:0] BB = BI ? ~B_buf : B_buf;
+   wire [Y_WIDTH-1:0] C = {CO, CI};
+   
+   genvar i;
+	generate for (i = 0; i < Y_WIDTH; i = i + 1) begin:slice
+	   fiftyfivenm_lcell_comb #(.lut_mask(LUT), .sum_lutc_input("cin")) _TECHMAP_REPLACE_ 
+	                                                                             ( .dataa(AA), 
+										       .datab(BB), 
+										       .datac(C), 
+										       .datad(1'b0), 
+										       .cin(C[i]), 
+										       .cout(CO[i]),
+										       .combout(Y[i]) );
+	  end: slice
+	endgenerate
+  assign X = C;
+endmodule
+   

--- a/techlibs/altera_intel/max10/cells_comb_max10.v
+++ b/techlibs/altera_intel/max10/cells_comb_max10.v
@@ -1,0 +1,128 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+ 
+module VCC (output V);
+   assign V = 1'b1;
+endmodule // VCC
+
+module GND (output G);
+   assign G = 1'b0;
+endmodule // GND
+
+/* Altera MAX10 devices Input Buffer Primitive */ 
+module fiftyfivenm_io_ibuf (output o, input i, input ibar);
+   assign ibar = ibar;
+   assign o    = i;
+endmodule // fiftyfivenm_io_ibuf
+
+/* Altera MAX10 devices Output Buffer Primitive */
+module fiftyfivenm_io_obuf (output o, input i, input oe);
+   assign o  = i;
+   assign oe = oe;
+endmodule // fiftyfivenm_io_obuf
+
+/* Altera MAX10 4-input non-fracturable LUT Primitive */ 
+module fiftyfivenm_lcell_comb (output combout, cout,
+                               input  dataa, datab, datac, datad, cin);
+                               
+/* Internal parameters which define the behaviour
+   of the LUT primitive.
+   lut_mask define the lut function, can be expressed in 16-digit bin or hex.
+   sum_lutc_input define the type of LUT (combinational | arithmetic). 
+   dont_touch for retiming || carry options.
+   lpm_type for WYSIWYG */   
+   
+parameter lut_mask = 16'hFFFF;
+parameter dont_touch = "off";
+parameter lpm_type = "fiftyfivenm_lcell_comb";
+parameter sum_lutc_input = "datac";
+  
+reg [1:0] lut_type;  
+reg cout_rt;
+reg combout_rt;
+wire dataa_w;
+wire datab_w;
+wire datac_w;
+wire datad_w;
+wire cin_w;
+
+assign dataa_w = dataa;
+assign datab_w = datab;
+assign datac_w = datac;
+assign datad_w = datad;
+
+function lut_data;
+input [15:0] mask;
+input        dataa, datab, datac, datad;
+reg [7:0]   s3;
+reg [3:0]   s2;
+reg [1:0]   s1;
+  begin
+       s3 = datad ? mask[15:8] : mask[7:0];
+       s2 = datac ?   s3[7:4]  :   s3[3:0];
+       s1 = datab ?   s2[3:2]  :   s2[1:0];
+       lut_data = dataa ? s1[1] : s1[0];
+  end
+
+endfunction
+
+initial begin
+    if (sum_lutc_input == "datac") lut_type = 0;
+    else 
+    if (sum_lutc_input == "cin")   lut_type = 1;
+    else begin
+      $error("Error in sum_lutc_input. Parameter %s is not a valid value.\n", sum_lutc_input);
+      $finish();
+    end
+end
+
+always @(dataa_w or datab_w or datac_w or datad_w or cin_w) begin
+    if (lut_type == 0) begin // logic function
+        combout_rt = lut_data(lut_mask, dataa_w, datab_w, 
+                            datac_w, datad_w);
+    end
+    else if (lut_type == 1) begin // arithmetic function
+        combout_rt = lut_data(lut_mask, dataa_w, datab_w, 
+                            cin_w, datad_w);
+    end
+    cout_rt = lut_data(lut_mask, dataa_w, datab_w, cin_w, 'b0);
+end
+
+assign combout = combout_rt & 1'b1;
+assign cout = cout_rt & 1'b1;
+
+endmodule // fiftyfivenm_lcell_comb
+
+/* Altera MAX10 D Flip-Flop Primitive */
+// TODO: Implement advanced simulation functions
+module dffeas ( output q, 
+                input d, clk, clrn, prn, ena, 
+		input asdata, aload, sclr, sload );
+  								     
+parameter power_up="dontcare";
+parameter is_wysiwyg="false";
+  reg q;
+
+  always @(posedge clk)
+    q <= d;
+   
+endmodule
+
+
+

--- a/techlibs/altera_intel/max10/cells_map_max10.v
+++ b/techlibs/altera_intel/max10/cells_map_max10.v
@@ -1,0 +1,61 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+ 
+// Flip-flop D
+module  \$_DFF_P_ (input D, input C, output Q);
+   parameter WYSIWYG="TRUE";
+   dffeas #(.is_wysiwyg(WYSIWYG)) _TECHMAP_REPLACE_ (.d(D), .q(Q), .clk(C), .clrn(1'b1), .prn(1'b1), .ena(1'b1), .asdata(1'b0), .aload(1'b0), .sclr(1'b0), .sload(1'b0));
+endmodule //
+
+// Input buffer map
+module \$__inpad (input I, output O);
+    fiftyfivenm_io_ibuf _TECHMAP_REPLACE_ (.o(O), .i(I), .ibar(1'b0));
+endmodule 
+
+// Output buffer map   
+module \$__outpad (input I, output O);
+    fiftyfivenm_io_obuf _TECHMAP_REPLACE_ (.o(O), .i(I), .oe(1'b1));
+endmodule 
+
+// LUT Map
+/* 0 -> datac
+   1 -> cin */
+module \$lut (A, Y);
+   parameter WIDTH  = 0;
+   parameter LUT    = 0;
+   input [WIDTH-1:0] A;
+   output 	     Y;
+   generate 
+      if (WIDTH == 1) begin
+	   assign Y = ~A[0]; // Not need to spend 1 logic cell for such an easy function
+      end else
+      if (WIDTH == 2) begin
+           fiftyfivenm_lcell_comb #(.lut_mask({4{LUT}}), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(1'b1),.datad(1'b1));
+      end else
+      if(WIDTH == 3) begin 
+	   fiftyfivenm_lcell_comb #(.lut_mask({2{LUT}}), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(A[2]),.datad(1'b1));
+      end else
+      if(WIDTH == 4) begin
+	   fiftyfivenm_lcell_comb #(.lut_mask(LUT), .sum_lutc_input("datac")) _TECHMAP_REPLACE_ (.combout(Y), .dataa(A[0]), .datab(A[1]), .datac(A[2]),.datad(A[3]));
+      end else
+	   wire _TECHMAP_FAIL_ = 1;
+   endgenerate
+endmodule //
+
+	    

--- a/techlibs/altera_intel/synth_intel.cc
+++ b/techlibs/altera_intel/synth_intel.cc
@@ -1,0 +1,199 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/register.h"
+#include "kernel/celltypes.h"
+#include "kernel/rtlil.h"
+#include "kernel/log.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct SynthIntelPass : public ScriptPass {
+	SynthIntelPass() : ScriptPass("synth_intel", "synthesis for Intel (Altera) FPGAs.") { }
+
+	virtual void help() YS_OVERRIDE
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    synth_intel [options]\n");
+		log("\n");
+		log("This command runs synthesis for Intel FPGAs. This work is still experimental.\n");
+		log("\n");
+		log("    -family < max10 | cycloneiv >\n");
+		log("        generate the synthesis netlist for the specified family.\n");
+		log("        MAX10 is the default target if not family argument specified \n");
+		log("\n");
+		log("    -top <module>\n");
+		log("        use the specified module as top module (default='top')\n");
+		log("\n");
+		log("    -vout <file>\n");
+		log("        write the design to the specified Verilog netlist file. writing of an\n");
+		log("        output file is omitted if this parameter is not specified.\n");
+		log("\n");
+		log("    -run <from_label>:<to_label>\n");
+		log("        only run the commands between the labels (see below). an empty\n");
+		log("        from label is synonymous to 'begin', and empty to label is\n");
+		log("        synonymous to the end of the command list.\n");
+		log("\n");
+		log("    -retime\n");
+		log("        run 'abc' with -dff option\n");
+		log("\n");
+		log("\n");
+		log("The following commands are executed by this synthesis command:\n");
+		help_script();
+		log("\n");
+	}
+
+        string top_opt, family_opt, vout_file;
+	bool retime;
+
+	virtual void clear_flags() YS_OVERRIDE
+	{
+		top_opt = "-auto-top";
+                family_opt = "max10";
+		vout_file = "";
+		retime = false;
+	}
+
+	virtual void execute(std::vector<std::string> args, RTLIL::Design *design) YS_OVERRIDE
+	{
+	  string run_from, run_to;
+		clear_flags();
+
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++)
+		{
+		        if (args[argidx] == "-family" && argidx+1 < args.size()) {
+				family_opt = args[++argidx];
+				continue;
+			}
+			if (args[argidx] == "-top" && argidx+1 < args.size()) {
+				top_opt = "-top " + args[++argidx];
+				continue;
+			}
+			if (args[argidx] == "-vout" && argidx+1 < args.size()) {
+				vout_file = args[++argidx];
+				continue;
+			}
+			if (args[argidx] == "-run" && argidx+1 < args.size()) {
+				size_t pos = args[argidx+1].find(':');
+				if (pos == std::string::npos)
+					break;
+				run_from = args[++argidx].substr(0, pos);
+				run_to = args[argidx].substr(pos+1);
+				continue;
+			}
+			if (args[argidx] == "-retime") {
+				retime = true;
+				continue;
+			}
+			break;
+		}
+		extra_args(args, argidx, design);
+
+		if (!design->full_selection())
+			log_cmd_error("This comannd only operates on fully selected designs!\n");
+		
+                if (family_opt != "max10" && family_opt !="cycloneiv" )
+		  log_cmd_error("Invalid or not family specified: '%s'\n", family_opt.c_str());
+
+		log_header(design, "Executing SYNTH_INTEL pass.\n");
+		log_push();
+
+		run_script(design, run_from, run_to);
+
+		log_pop();
+	}
+
+	virtual void script() YS_OVERRIDE
+	{
+	  if (check_label("begin"))
+	  {
+		  if(check_label("family") && family_opt=="max10")
+		  {
+			run("read_verilog -lib +/altera_intel/max10/cells_comb_max10.v");
+			run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+		  }
+		  else
+		  {
+		      run("read_verilog -lib +/altera_intel/cycloneiv/cells_comb_cycloneiv.v");
+		      run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));
+		  }
+	  }
+
+		if (check_label("flatten"))
+		{
+			run("proc");
+			run("flatten");
+			run("tribuf -logic");
+			run("deminout");
+		}
+
+		if (check_label("coarse"))
+		{
+			run("synth -run coarse");
+		}
+
+		if (check_label("fine"))
+		{
+		        run("opt -fast -full");
+			run("memory_map");
+			run("opt -full");
+			run("techmap -map +/techmap.v");
+                        run("opt -fast");
+			run("clean -purge");
+			run("setundef -undriven -zero");
+			if (retime || help_mode)
+				run("abc -dff", "(only if -retime)");
+		}
+
+		if (check_label("map_luts"))
+		{
+		        run("abc -lut 4");
+			run("clean");
+		}
+
+		if (check_label("map_cells"))
+		{
+			run("iopadmap -bits -outpad $__outpad I:O -inpad $__inpad O:I");
+			if(family_opt=="max10")
+			  run("techmap -map +/altera_intel/max10/cells_map_max10.v");
+			else
+			  run("techmap -map +/altera_intel/cycloneiv/cells_map_cycloneiv.v");
+			run("clean -purge");
+		}
+
+		if (check_label("check"))
+		{
+			run("hierarchy -check");
+			run("stat");
+			run("check -noinit");
+		}
+
+		if (check_label("vout"))
+		{
+			if (!vout_file.empty() || help_mode)
+				run(stringf("write_verilog -nodec -attr2comment -defparam -nohex -renameprefix yosys_ %s",
+						help_mode ? "<file-name>" : vout_file.c_str()));
+		}
+	}
+} SynthIntelPass;
+
+PRIVATE_NAMESPACE_END


### PR DESCRIPTION
Dear Clifford,
I have:
 - Removed the Quartus project copyright.
 - Cleaned the iverilog outputs.
 - Keeping Yosys version (0.7).
 - Doing a clean pull request.

I suggest the following text in CHANGELOG, but is up to you if you want to modify for something else:
     - Added Contributor dh73, Code of Conduct.
     - Added initial version of metacommand "synth_intel".
     - Improved write_verilog command to produce VQM netlist for Quartus Prime.
     - Added support for MAX10 FPGA family synthesis.
     - Added support for Cyclone IV family synthesis.
     - Added example of implementation for DE2i-150 board.
     - Added example of implementation for MAX10 development kit.
     - Added LFSR example from Asic World. 

Looking forward to see if this request satisfies the criteria now.