### PR TITLE
Excluded $_TBUF_ from opt_merge pass

### DIFF
--- a/passes/opt/opt_merge.cc
+++ b/passes/opt/opt_merge.cc
@@ -276,6 +276,7 @@ struct OptMergeWorker
 		}
 
 		ct.cell_types.erase("$tribuf");
+		ct.cell_types.erase("$_TBUF_");
 		ct.cell_types.erase("$anyseq");
 		ct.cell_types.erase("$anyconst");
 


### PR DESCRIPTION
This is the same you did for $tribuf but applied to $_TBUF_ (I'm using iCE40HX4K FPGAs)