### PR TITLE
Added opt_rmports pass

### DIFF
--- a/passes/opt/Makefile.inc
+++ b/passes/opt/Makefile.inc
@@ -6,7 +6,7 @@ OBJS += passes/opt/opt_reduce.o
 OBJS += passes/opt/opt_rmdff.o
 OBJS += passes/opt/opt_clean.o
 OBJS += passes/opt/opt_expr.o
-OBJS += passes/opt/opt_rmports.o
+OBJS += passes/opt/rmports.o
 
 ifneq ($(SMALL),1)
 OBJS += passes/opt/share.o

--- a/passes/opt/Makefile.inc
+++ b/passes/opt/Makefile.inc
@@ -6,6 +6,7 @@ OBJS += passes/opt/opt_reduce.o
 OBJS += passes/opt/opt_rmdff.o
 OBJS += passes/opt/opt_clean.o
 OBJS += passes/opt/opt_expr.o
+OBJS += passes/opt/opt_rmports.o
 
 ifneq ($(SMALL),1)
 OBJS += passes/opt/share.o

--- a/passes/opt/opt_rmports.cc
+++ b/passes/opt/opt_rmports.cc
@@ -90,6 +90,9 @@ struct OptRmportsPass : public Pass {
 				for(int i=0; i<conn.second.size(); i++)
 				{
 					auto sig = conn.second[i].wire;
+					if(sig == NULL)
+						continue;
+
 					//log("  sig %s\n", sig->name.c_str());
 					if( (sig->port_input || sig->port_output) && (used_ports.find(sig->name) == used_ports.end()) )
 						used_ports.emplace(sig->name);

--- a/passes/opt/opt_rmports.cc
+++ b/passes/opt/opt_rmports.cc
@@ -56,14 +56,28 @@ struct OptRmportsPass : public Pass {
 		auto& conns = module->connections();
 		for(auto sigsig : conns)
 		{
-			auto s1 = sigsig.first.as_wire();
-			auto s2 = sigsig.second.as_wire();
+			auto s1 = sigsig.first;
+			auto s2 = sigsig.second;
 
-			if( (s1->port_input || s1->port_output) && (used_ports.find(s1->name) == used_ports.end()) )
-				used_ports.emplace(s1->name);
+			int len1 = s1.size();
+			int len2 = s2.size();
+			int len = len1;
+			if(len2 < len1)
+				len = len2;
 
-			if( (s2->port_input || s2->port_output) && (used_ports.find(s2->name) == used_ports.end()) )
-				used_ports.emplace(s2->name);
+			for(int i=0; i<len; i++)
+			{
+				auto w1 = s1[i].wire;
+				auto w2 = s2[i].wire;
+
+				//log("  conn %s, %s\n", w1->name.c_str(), w2->name.c_str());
+
+				if( (w1->port_input || w1->port_output) && (used_ports.find(w1->name) == used_ports.end()) )
+					used_ports.emplace(w1->name);
+
+				if( (w2->port_input || w2->port_output) && (used_ports.find(w2->name) == used_ports.end()) )
+					used_ports.emplace(w2->name);
+			}
 		}
 
 		//Then check connections to cells
@@ -73,12 +87,13 @@ struct OptRmportsPass : public Pass {
 			auto& cconns = cell->connections();
 			for(auto conn : cconns)
 			{
-				if(!conn.second.is_wire())
-					continue;
-				auto sig = conn.second.as_wire();
-
-				if( (sig->port_input || sig->port_output) && (used_ports.find(sig->name) == used_ports.end()) )
-					used_ports.emplace(sig->name);
+				for(int i=0; i<conn.second.size(); i++)
+				{
+					auto sig = conn.second[i].wire;
+					//log("  sig %s\n", sig->name.c_str());
+					if( (sig->port_input || sig->port_output) && (used_ports.find(sig->name) == used_ports.end()) )
+						used_ports.emplace(sig->name);
+				}
 			}
 		}
 

--- a/passes/opt/opt_rmports.cc
+++ b/passes/opt/opt_rmports.cc
@@ -69,6 +69,8 @@ struct OptRmportsPass : public Pass {
 			{
 				auto w1 = s1[i].wire;
 				auto w2 = s2[i].wire;
+				if( (w1 == NULL) || (w2 == NULL) )
+					continue;
 
 				//log("  conn %s, %s\n", w1->name.c_str(), w2->name.c_str());
 

--- a/passes/opt/opt_rmports.cc
+++ b/passes/opt/opt_rmports.cc
@@ -1,0 +1,132 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/register.h"
+#include "kernel/sigtools.h"
+#include "kernel/log.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+struct OptRmportsPass : public Pass {
+	OptRmportsPass() : Pass("opt_rmports", "remove top-level ports with no connections") { }
+	virtual void help()
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    opt_rmports\n");
+		log("\n");
+		log("This pass identifies ports in the top-level design which are not used or driven\n");
+		log("and removes them\n");
+		log("\n");
+	}
+
+	virtual void execute(std::vector<std::string> /*args*/, RTLIL::Design *design)
+	{
+		log_header(design, "Executing OPT_RMPORTS pass (remove top level ports with no connections).\n");
+
+		//vector<RTLIL::Module*> mods = design->modules();
+		//for(auto mod : mods)
+		//	ProcessModule(mod);
+		ProcessModule(design->top_module());
+	}
+
+	virtual void ProcessModule(RTLIL::Module* module)
+	{
+		log("Finding unconnected ports in module %s\n", module->name.c_str());
+
+		std::set<RTLIL::IdString> used_ports;
+
+		//See what wires are used.
+		//Start by checking connections between named wires
+		auto& conns = module->connections();
+		for(auto sigsig : conns)
+		{
+			auto s1 = sigsig.first.as_wire();
+			auto s2 = sigsig.second.as_wire();
+
+			if( (s1->port_input || s1->port_output) && (used_ports.find(s1->name) == used_ports.end()) )
+				used_ports.emplace(s1->name);
+
+			if( (s2->port_input || s2->port_output) && (used_ports.find(s2->name) == used_ports.end()) )
+				used_ports.emplace(s2->name);
+		}
+
+		//Then check connections to cells
+		auto cells = module->cells();
+		for(auto cell : cells)
+		{
+			auto& cconns = cell->connections();
+			for(auto conn : cconns)
+			{
+				if(!conn.second.is_wire())
+					continue;
+				auto sig = conn.second.as_wire();
+
+				if( (sig->port_input || sig->port_output) && (used_ports.find(sig->name) == used_ports.end()) )
+					used_ports.emplace(sig->name);
+			}
+		}
+
+		//Now that we know what IS used, get rid of anything that isn't in that list
+		std::set<RTLIL::IdString> unused_ports;
+		for(auto port : module->ports)
+		{
+			if(used_ports.find(port) != used_ports.end())
+				continue;
+			unused_ports.emplace(port);
+		}
+
+		//Print the ports out as we go through them
+		for(auto port : unused_ports)
+		{
+			log("  removing unused top-level port %s\n", port.c_str());
+
+			//Remove from ports list
+			for(size_t i=0; i<module->ports.size(); i++)
+			{
+				if(module->ports[i] == port)
+				{
+					module->ports.erase(module->ports.begin() + i);
+					break;
+				}
+			}
+
+			//Mark the wire as no longer a port
+			auto wire = module->wire(port);
+			wire->port_input = false;
+			wire->port_output = false;
+			wire->port_id = 0;
+		}
+		log("Removed %zu unused top-level ports.\n", unused_ports.size());
+
+		//Re-number all of the wires that DO have ports still on them
+		for(size_t i=0; i<module->ports.size(); i++)
+		{
+			auto port = module->ports[i];
+			auto wire = module->wire(port);
+			wire->port_id = i+1;
+		}
+	}
+
+} OptRmportsPass;
+
+PRIVATE_NAMESPACE_END

--- a/passes/opt/opt_rmports.cc
+++ b/passes/opt/opt_rmports.cc
@@ -42,10 +42,6 @@ struct OptRmportsPass : public Pass {
 	virtual void execute(std::vector<std::string> /*args*/, RTLIL::Design *design)
 	{
 		log_header(design, "Executing OPT_RMPORTS pass (remove top level ports with no connections).\n");
-
-		//vector<RTLIL::Module*> mods = design->modules();
-		//for(auto mod : mods)
-		//	ProcessModule(mod);
 		ProcessModule(design->top_module());
 	}
 

--- a/passes/opt/rmports.cc
+++ b/passes/opt/rmports.cc
@@ -26,13 +26,13 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-struct OptRmportsPass : public Pass {
-	OptRmportsPass() : Pass("opt_rmports", "remove top-level ports with no connections") { }
+struct RmportsPassPass : public Pass {
+	RmportsPassPass() : Pass("rmports", "remove top-level ports with no connections") { }
 	virtual void help()
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
 		log("\n");
-		log("    opt_rmports\n");
+		log("    rmports\n");
 		log("\n");
 		log("This pass identifies ports in the top-level design which are not used or driven\n");
 		log("and removes them\n");
@@ -41,7 +41,7 @@ struct OptRmportsPass : public Pass {
 
 	virtual void execute(std::vector<std::string> /*args*/, RTLIL::Design *design)
 	{
-		log_header(design, "Executing OPT_RMPORTS pass (remove top level ports with no connections).\n");
+		log_header(design, "Executing RMPORTS pass (remove top level ports with no connections).\n");
 		ProcessModule(design->top_module());
 	}
 
@@ -143,6 +143,6 @@ struct OptRmportsPass : public Pass {
 		}
 	}
 
-} OptRmportsPass;
+} RmportsPassPass;
 
 PRIVATE_NAMESPACE_END

--- a/passes/opt/rmports.cc
+++ b/passes/opt/rmports.cc
@@ -27,7 +27,7 @@ USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
 struct RmportsPassPass : public Pass {
-	RmportsPassPass() : Pass("rmports", "remove top-level ports with no connections") { }
+	RmportsPassPass() : Pass("rmports", "remove module ports with no connections") { }
 	virtual void help()
 	{
 		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
@@ -42,7 +42,10 @@ struct RmportsPassPass : public Pass {
 	virtual void execute(std::vector<std::string> /*args*/, RTLIL::Design *design)
 	{
 		log_header(design, "Executing RMPORTS pass (remove top level ports with no connections).\n");
-		ProcessModule(design->top_module());
+
+		auto modules = design->selected_modules();
+		for(auto mod : modules)
+			ProcessModule(mod);
 	}
 
 	virtual void ProcessModule(RTLIL::Module* module)
@@ -114,7 +117,7 @@ struct RmportsPassPass : public Pass {
 		//Print the ports out as we go through them
 		for(auto port : unused_ports)
 		{
-			log("  removing unused top-level port %s\n", port.c_str());
+			log("  removing unused port %s\n", port.c_str());
 
 			//Remove from ports list
 			for(size_t i=0; i<module->ports.size(); i++)
@@ -132,7 +135,7 @@ struct RmportsPassPass : public Pass {
 			wire->port_output = false;
 			wire->port_id = 0;
 		}
-		log("Removed %zu unused top-level ports.\n", unused_ports.size());
+		log("Removed %zu unused ports.\n", unused_ports.size());
 
 		//Re-number all of the wires that DO have ports still on them
 		for(size_t i=0; i<module->ports.size(); i++)

--- a/passes/opt/rmports.cc
+++ b/passes/opt/rmports.cc
@@ -48,7 +48,7 @@ struct RmportsPassPass : public Pass {
 			ProcessModule(mod);
 	}
 
-	virtual void ProcessModule(RTLIL::Module* module)
+	void ProcessModule(RTLIL::Module* module)
 	{
 		log("Finding unconnected ports in module %s\n", module->name.c_str());
 


### PR DESCRIPTION
This is a special-use optimization pass (should NOT be called by default when the "opt" command is run) that deletes all top-level ports in the design that have no cells connected to them.