### PR TITLE
Add support for source line tracking through synthesis phase

### DIFF
--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1620,18 +1620,19 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, const RTLIL::Cell *oth
 }
 
 #define DEF_METHOD(_func, _y_size, _type) \
-	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed) { \
+		RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed, std::string src) { \
 		RTLIL::Cell *cell = addCell(name, _type);           \
 		cell->parameters["\\A_SIGNED"] = is_signed;         \
 		cell->parameters["\\A_WIDTH"] = sig_a.size();       \
 		cell->parameters["\\Y_WIDTH"] = sig_y.size();       \
 		cell->setPort("\\A", sig_a);                        \
 		cell->setPort("\\Y", sig_y);                        \
+		if (!src.empty()) cell->attributes["\\src"] = src;  \
 		return cell;                                        \
 	} \
-	RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed) { \
+		RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed, std::string src) { \
 		RTLIL::SigSpec sig_y = addWire(NEW_ID, _y_size);    \
-		add ## _func(name, sig_a, sig_y, is_signed);        \
+		add ## _func(name, sig_a, sig_y, is_signed, src);   \
 		return sig_y;                                       \
 	}
 DEF_METHOD(Not,        sig_a.size(), "$not")

--- a/kernel/rtlil.cc
+++ b/kernel/rtlil.cc
@@ -1620,7 +1620,7 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, const RTLIL::Cell *oth
 }
 
 #define DEF_METHOD(_func, _y_size, _type) \
-		RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed, std::string src) { \
+	RTLIL::Cell* RTLIL::Module::add ## _func(RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed, std::string src) { \
 		RTLIL::Cell *cell = addCell(name, _type);           \
 		cell->parameters["\\A_SIGNED"] = is_signed;         \
 		cell->parameters["\\A_WIDTH"] = sig_a.size();       \
@@ -1630,7 +1630,7 @@ RTLIL::Cell *RTLIL::Module::addCell(RTLIL::IdString name, const RTLIL::Cell *oth
 		if (!src.empty()) cell->attributes["\\src"] = src;  \
 		return cell;                                        \
 	} \
-		RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed, std::string src) { \
+	RTLIL::SigSpec RTLIL::Module::_func(RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed, std::string src) { \
 		RTLIL::SigSpec sig_y = addWire(NEW_ID, _y_size);    \
 		add ## _func(name, sig_a, sig_y, is_signed, src);   \
 		return sig_y;                                       \

--- a/kernel/rtlil.h
+++ b/kernel/rtlil.h
@@ -960,20 +960,20 @@ public:
 
 	// The add* methods create a cell and return the created cell. All signals must exist in advance.
 
-	RTLIL::Cell* addNot (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false);
-	RTLIL::Cell* addPos (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false);
-	RTLIL::Cell* addNeg (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false);
+	RTLIL::Cell* addNot (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false, std::string src = "");
+	RTLIL::Cell* addPos (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false, std::string src = "");
+	RTLIL::Cell* addNeg (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false, std::string src = "");
 
 	RTLIL::Cell* addAnd  (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, bool is_signed = false);
 	RTLIL::Cell* addOr   (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, bool is_signed = false);
 	RTLIL::Cell* addXor  (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, bool is_signed = false);
 	RTLIL::Cell* addXnor (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, bool is_signed = false);
 
-	RTLIL::Cell* addReduceAnd  (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false);
-	RTLIL::Cell* addReduceOr   (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false);
-	RTLIL::Cell* addReduceXor  (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false);
-	RTLIL::Cell* addReduceXnor (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false);
-	RTLIL::Cell* addReduceBool (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false);
+	RTLIL::Cell* addReduceAnd  (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false, std::string src = "");
+	RTLIL::Cell* addReduceOr   (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false, std::string src = "");
+	RTLIL::Cell* addReduceXor  (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false, std::string src = "");
+	RTLIL::Cell* addReduceXnor (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false, std::string src = "");
+	RTLIL::Cell* addReduceBool (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false, std::string src = "");
 
 	RTLIL::Cell* addShl    (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, bool is_signed = false);
 	RTLIL::Cell* addShr    (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, bool is_signed = false);
@@ -998,7 +998,7 @@ public:
 	RTLIL::Cell* addMod (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, bool is_signed = false);
 	RTLIL::Cell* addPow (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, bool a_signed = false, bool b_signed = false);
 
-	RTLIL::Cell* addLogicNot (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false);
+	RTLIL::Cell* addLogicNot (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_y, bool is_signed = false, std::string src = "");
 	RTLIL::Cell* addLogicAnd (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, bool is_signed = false);
 	RTLIL::Cell* addLogicOr  (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, RTLIL::SigSpec sig_y, bool is_signed = false);
 
@@ -1057,21 +1057,21 @@ public:
 
 	// The methods without the add* prefix create a cell and an output signal. They return the newly created output signal.
 
-	RTLIL::SigSpec Not (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false);
-	RTLIL::SigSpec Pos (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false);
+	RTLIL::SigSpec Not (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false, std::string src = "");
+	RTLIL::SigSpec Pos (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false, std::string src = "");
 	RTLIL::SigSpec Bu0 (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false);
-	RTLIL::SigSpec Neg (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false);
+	RTLIL::SigSpec Neg (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false, std::string src = "");
 
 	RTLIL::SigSpec And  (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, bool is_signed = false);
 	RTLIL::SigSpec Or   (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, bool is_signed = false);
 	RTLIL::SigSpec Xor  (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, bool is_signed = false);
 	RTLIL::SigSpec Xnor (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, bool is_signed = false);
 
-	RTLIL::SigSpec ReduceAnd  (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false);
-	RTLIL::SigSpec ReduceOr   (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false);
-	RTLIL::SigSpec ReduceXor  (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false);
-	RTLIL::SigSpec ReduceXnor (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false);
-	RTLIL::SigSpec ReduceBool (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false);
+	RTLIL::SigSpec ReduceAnd  (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false, std::string src = "");
+	RTLIL::SigSpec ReduceOr   (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false, std::string src = "");
+	RTLIL::SigSpec ReduceXor  (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false, std::string src = "");
+	RTLIL::SigSpec ReduceXnor (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false, std::string src = "");
+	RTLIL::SigSpec ReduceBool (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false, std::string src = "");
 
 	RTLIL::SigSpec Shl    (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, bool is_signed = false);
 	RTLIL::SigSpec Shr    (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, bool is_signed = false);
@@ -1096,7 +1096,7 @@ public:
 	RTLIL::SigSpec Mod (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, bool is_signed = false);
 	RTLIL::SigSpec Pow (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, bool a_signed = false, bool b_signed = false);
 
-	RTLIL::SigSpec LogicNot (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false);
+	RTLIL::SigSpec LogicNot (RTLIL::IdString name, RTLIL::SigSpec sig_a, bool is_signed = false, std::string src = "");
 	RTLIL::SigSpec LogicAnd (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, bool is_signed = false);
 	RTLIL::SigSpec LogicOr  (RTLIL::IdString name, RTLIL::SigSpec sig_a, RTLIL::SigSpec sig_b, bool is_signed = false);
 

--- a/passes/techmap/alumacc.cc
+++ b/passes/techmap/alumacc.cc
@@ -352,13 +352,12 @@ struct AlumaccWorker
 		{
 			auto n = it.second;
 			auto cell = module->addCell(NEW_ID, "$macc");
-			auto src = n->cell->attributes["\\src"].decode_string();
 
 			macc_counter++;
 
 			log("  creating $macc cell for %s: %s\n", log_id(n->cell), log_id(cell));
 
-			if (!src.empty()) cell->attributes["\\src"] = src;
+			cell->set_src_attribute(n->cell->get_src_attribute());
 
 			n->macc.optimize(GetSize(n->y));
 			n->macc.to_cell(cell);
@@ -480,8 +479,8 @@ struct AlumaccWorker
 				log("%s%s", i ? ", ": "", log_id(n->cells[i]));
 			log(": %s\n", log_id(n->alu_cell));
 
-			src = n->cells.size() > 0 ? n->cells[0]->attributes["\\src"].decode_string() : "";
-			if (!src.empty()) n->alu_cell->attributes["\\src"] = src;
+			if (n->cells.size() > 0)
+				n->alu_cell->set_src_attribute(n->cells[0]->get_src_attribute());
 
 			n->alu_cell->setPort("\\A", n->a);
 			n->alu_cell->setPort("\\B", n->b);

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -478,10 +478,14 @@ static void dfflibmap(RTLIL::Design *design, RTLIL::Module *module, bool prepare
 		auto cell_type = cell->type;
 		auto cell_name = cell->name;
 		auto cell_connections = cell->connections();
+		std::string src = cell->attributes["\\src"].decode_string();
+
 		module->remove(cell);
 
 		cell_mapping &cm = cell_mappings[cell_type];
 		RTLIL::Cell *new_cell = module->addCell(cell_name, prepare_mode ? cm.cell_name : "\\" + cm.cell_name);
+
+		if (!src.empty()) new_cell->attributes["\\src"] = src;
 
 		bool has_q = false, has_qn = false;
 		for (auto &port : cm.ports) {

--- a/passes/techmap/dfflibmap.cc
+++ b/passes/techmap/dfflibmap.cc
@@ -478,14 +478,14 @@ static void dfflibmap(RTLIL::Design *design, RTLIL::Module *module, bool prepare
 		auto cell_type = cell->type;
 		auto cell_name = cell->name;
 		auto cell_connections = cell->connections();
-		std::string src = cell->attributes["\\src"].decode_string();
+		std::string src = cell->get_src_attribute();
 
 		module->remove(cell);
 
 		cell_mapping &cm = cell_mappings[cell_type];
 		RTLIL::Cell *new_cell = module->addCell(cell_name, prepare_mode ? cm.cell_name : "\\" + cm.cell_name);
 
-		if (!src.empty()) new_cell->attributes["\\src"] = src;
+		new_cell->set_src_attribute(src);
 
 		bool has_q = false, has_qn = false;
 		for (auto &port : cm.ports) {

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -172,6 +172,7 @@ struct TechmapWorker
 
 		std::string orig_cell_name;
 		pool<string> extra_src_attrs;
+		std::string src = cell->attributes["\\src"].decode_string();
 
 		if (!flatten_mode)
 		{
@@ -340,6 +341,8 @@ struct TechmapWorker
 			RTLIL::Cell *c = module->addCell(c_name, it.second);
 			design->select(module, c);
 
+			if (!src.empty()) c->attributes["\\src"] = src;
+
 			if (!flatten_mode && c->type.substr(0, 2) == "\\$")
 				c->type = c->type.substr(1);
 
@@ -464,7 +467,9 @@ struct TechmapWorker
 			log_assert(cell == module->cell(cell->name));
 			bool mapped_cell = false;
 
+			std::string src       = cell->attributes["\\src"].decode_string();
 			std::string cell_type = cell->type.str();
+
 			if (in_recursion && cell_type.substr(0, 2) == "\\$")
 				cell_type = cell_type.substr(1);
 
@@ -511,6 +516,8 @@ struct TechmapWorker
 							{
 								extmapper_module = extmapper_design->addModule(m_name);
 								RTLIL::Cell *extmapper_cell = extmapper_module->addCell(cell->type, cell);
+
+								if (!src.empty()) extmapper_cell->attributes["\\src"] = src;
 
 								int port_counter = 1;
 								for (auto &c : extmapper_cell->connections_) {

--- a/passes/techmap/techmap.cc
+++ b/passes/techmap/techmap.cc
@@ -172,7 +172,6 @@ struct TechmapWorker
 
 		std::string orig_cell_name;
 		pool<string> extra_src_attrs;
-		std::string src = cell->attributes["\\src"].decode_string();
 
 		if (!flatten_mode)
 		{
@@ -341,7 +340,7 @@ struct TechmapWorker
 			RTLIL::Cell *c = module->addCell(c_name, it.second);
 			design->select(module, c);
 
-			if (!src.empty()) c->attributes["\\src"] = src;
+			c->set_src_attribute(cell->get_src_attribute());
 
 			if (!flatten_mode && c->type.substr(0, 2) == "\\$")
 				c->type = c->type.substr(1);
@@ -467,7 +466,6 @@ struct TechmapWorker
 			log_assert(cell == module->cell(cell->name));
 			bool mapped_cell = false;
 
-			std::string src       = cell->attributes["\\src"].decode_string();
 			std::string cell_type = cell->type.str();
 
 			if (in_recursion && cell_type.substr(0, 2) == "\\$")
@@ -517,7 +515,7 @@ struct TechmapWorker
 								extmapper_module = extmapper_design->addModule(m_name);
 								RTLIL::Cell *extmapper_cell = extmapper_module->addCell(cell->type, cell);
 
-								if (!src.empty()) extmapper_cell->attributes["\\src"] = src;
+								extmapper_cell->set_src_attribute(cell->get_src_attribute());
 
 								int port_counter = 1;
 								for (auto &c : extmapper_cell->connections_) {


### PR DESCRIPTION
These are some minor edits to help retain source line tracking information on cells through some of the synthesis passes, i.e. propagate "src" attributes from original cells to the derived cells they are being replaced with. 