### PR TITLE
extract_reduce: Fix segfault on "undriven" inputs

### DIFF
--- a/passes/techmap/extract_reduce.cc
+++ b/passes/techmap/extract_reduce.cc
@@ -160,7 +160,7 @@ struct ExtractReducePass : public Pass
 					if (sig_to_sink[a[0]].size() + port_sigs.count(a[0]) == 1)
 					{
 						Cell* cell_a = sig_to_driver[a[0]];
-						if (((cell_a->type == "$_AND_" && gt == GateType::And) ||
+						if (cell_a && ((cell_a->type == "$_AND_" && gt == GateType::And) ||
 							(cell_a->type == "$_OR_" && gt == GateType::Or) ||
 							(cell_a->type == "$_XOR_" && gt == GateType::Xor)))
 						{
@@ -177,7 +177,7 @@ struct ExtractReducePass : public Pass
 					if (sig_to_sink[b[0]].size() + port_sigs.count(b[0]) == 1)
 					{
 						Cell* cell_b = sig_to_driver[b[0]];
-						if (((cell_b->type == "$_AND_" && gt == GateType::And) ||
+						if (cell_b && ((cell_b->type == "$_AND_" && gt == GateType::And) ||
 							(cell_b->type == "$_OR_" && gt == GateType::Or) ||
 							(cell_b->type == "$_XOR_" && gt == GateType::Xor)))
 						{


### PR DESCRIPTION
This is easily triggered when un-techmapping if the technology-specific
cell library isn't loaded. Outputs of technology-specific cells will be
seen as inputs, and nets using those outputs will be seen as undriven.
Just ignore these cells because they can't be part of a reduce chain
anyways.