### PR TITLE
Added support for off-chain loads in extract_reduce

### DIFF
--- a/passes/techmap/extract_reduce.cc
+++ b/passes/techmap/extract_reduce.cc
@@ -76,6 +76,7 @@ struct ExtractReducePass : public Pass
 				allow_off_chain = true;
 				continue;
 			}
+			break;
 		}
 		extra_args(args, argidx, design);
 


### PR DESCRIPTION
Added an optional, non-default argument that makes "extract_reduce" infer a reduction operation even if intermediate gates in the reduction chain drive other logic. This can lead to needless replication of logic and an increase in design area, but is a useful intermediate in coarse-grained synthesis and reverse engineering flows.