### PR TITLE
Add $bits() and $size()

### DIFF
--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1883,17 +1883,19 @@ skip_dynamic_range_lvalue_expansion:;
 				int dim = 1;
 				if (str == "\\$size" && children.size() == 2) {
 					AstNode *buf = children[1]->clone();
+					// Evaluate constant expression
+					while (buf->simplify(true, false, false, stage, width_hint, sign_hint, false)) { }
 					dim = buf->asInt(false);
 					delete buf;
 				}
 				AstNode *buf = children[0]->clone();
 				int mem_depth = 1;
 				AstNode *id_ast = NULL;
-				
 
 				// Is this needed?
 				//while (buf->simplify(true, false, false, stage, width_hint, sign_hint, false)) { }
 				buf->detectSignWidth(width_hint, sign_hint);
+
 				if (buf->type == AST_IDENTIFIER) {
 					id_ast = buf->id2ast;
 					if (id_ast == NULL && current_scope.count(buf->str))
@@ -1907,30 +1909,28 @@ skip_dynamic_range_lvalue_expansion:;
 						if (str == "\\$bits") {
 							if (mem_range->type == AST_RANGE) {
 								if (!mem_range->range_valid)
-									log_error("Failed to detect width of memory access `%s' at %s:%d!\n", mem_range->str.c_str(), filename.c_str(), linenum);
+									log_error("Failed to detect width of memory access `%s' at %s:%d!\n", buf->str.c_str(), filename.c_str(), linenum);
 								mem_depth = mem_range->range_left - mem_range->range_right + 1;
-							} else if (mem_range->type == AST_MULTIRANGE) {
-								for (auto n : mem_range->children) 
-									mem_depth *= (n->range_left - n->range_right + 1);
 							} else
-								log_error("Unknown memory depth AST type in `%s' at %s:%d!\n", mem_range->str.c_str(), filename.c_str(), linenum);
+								log_error("Unknown memory depth AST type in `%s' at %s:%d!\n", buf->str.c_str(), filename.c_str(), linenum);
 						} else {
 							// $size()
 							if (mem_range->type == AST_RANGE) {
 								if (!mem_range->range_valid)
-									log_error("Failed to detect width of memory access `%s' at %s:%d!\n", mem_range->str.c_str(), filename.c_str(), linenum);
+									log_error("Failed to detect width of memory access `%s' at %s:%d!\n", buf->str.c_str(), filename.c_str(), linenum);
+								int dims;
+								if (id_ast->multirange_dimensions.empty())
+									dims = 1;
+								else
+									dims = GetSize(id_ast->multirange_dimensions)/2;
 								if (dim == 1)
-									width_hint = mem_range->range_left - mem_range->range_right + 1;
-							} else if (mem_range->type == AST_MULTIRANGE) {
-								log("multirange!\n");
-								int s = mem_range->children.size();
-								if (dim <= s) {
-									auto n = mem_range->children[dim-1]; 
-									width_hint = (n->range_left - n->range_right + 1);
-								} else if (dim > s+1)
-									log_error("Dimension %d out of range in `%s', as it only has dimensions 1..%d at %s:%d!\n", dim, mem_range->str.c_str(), s+1, filename.c_str(), linenum);
+									width_hint = (dims > 1) ? id_ast->multirange_dimensions[1] : (mem_range->range_left - mem_range->range_right + 1);
+								else if (dim <= dims) {
+									width_hint = id_ast->multirange_dimensions[2*dim-1];
+								} else if ((dim > dims+1) || (dim < 0))
+									log_error("Dimension %d out of range in `%s', as it only has dimensions 1..%d at %s:%d!\n", dim, buf->str.c_str(), dims+1, filename.c_str(), linenum);
 							} else
-								log_error("Unknown memory depth AST type in `%s' at %s:%d!\n", mem_range->str.c_str(), filename.c_str(), linenum);
+								log_error("Unknown memory depth AST type in `%s' at %s:%d!\n", buf->str.c_str(), filename.c_str(), linenum);
 						}
 					}
 				}

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -387,7 +387,7 @@ bool AstNode::simplify(bool const_fold, bool at_zero, bool in_lvalue, int stage,
 		}
 		for (size_t i = 0; i < children.size(); i++) {
 			AstNode *node = children[i];
-			if (node->type == AST_PARAMETER || node->type == AST_LOCALPARAM || node->type == AST_WIRE || node->type == AST_AUTOWIRE)
+			if (node->type == AST_PARAMETER || node->type == AST_LOCALPARAM || node->type == AST_WIRE || node->type == AST_AUTOWIRE || node->type == AST_MEMORY)
 				while (node->simplify(true, false, false, 1, -1, false, node->type == AST_PARAMETER || node->type == AST_LOCALPARAM))
 					did_something = true;
 		}
@@ -1877,6 +1877,8 @@ skip_dynamic_range_lvalue_expansion:;
 							RTLIL::unescape_id(str).c_str(), int(children.size()), filename.c_str(), linenum);
 
 				AstNode *buf = children[0]->clone();
+				// Is this needed?
+				//while (buf->simplify(true, false, false, stage, width_hint, sign_hint, false)) { }
 				buf->detectSignWidth(width_hint, sign_hint);
 				delete buf;
 

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1870,6 +1870,20 @@ skip_dynamic_range_lvalue_expansion:;
 				goto apply_newNode;
 			}
 
+			if (str == "\\$size")
+			{
+				if (children.size() != 1)
+					log_error("System function %s got %d arguments, expected 1 at %s:%d.\n",
+							RTLIL::unescape_id(str).c_str(), int(children.size()), filename.c_str(), linenum);
+
+				AstNode *buf = children[0]->clone();
+				buf->detectSignWidth(width_hint, sign_hint);
+				delete buf;
+
+				newNode = mkconst_int(width_hint, false);
+				goto apply_newNode;
+			}
+
 			if (str == "\\$ln" || str == "\\$log10" || str == "\\$exp" || str == "\\$sqrt" || str == "\\$pow" ||
 					str == "\\$floor" || str == "\\$ceil" || str == "\\$sin" || str == "\\$cos" || str == "\\$tan" ||
 					str == "\\$asin" || str == "\\$acos" || str == "\\$atan" || str == "\\$atan2" || str == "\\$hypot" ||

--- a/frontends/ast/simplify.cc
+++ b/frontends/ast/simplify.cc
@@ -1870,7 +1870,7 @@ skip_dynamic_range_lvalue_expansion:;
 				goto apply_newNode;
 			}
 
-			if (str == "\\$size" || str == "\\$bits")
+			if (VERILOG_FRONTEND::sv_mode && (str == "\\$size" || str == "\\$bits"))
 			{
 				if (children.size() != 1)
 					log_error("System function %s got %d arguments, expected 1 at %s:%d.\n",

--- a/tests/simple/functions01.sv
+++ b/tests/simple/functions01.sv
@@ -1,4 +1,5 @@
 module functions01;
+
 wire [3:0]x;
 wire [$size(x)-1:0]x_size;
 wire [$size({x, x})-1:0]xx_size;
@@ -7,11 +8,9 @@ wire [$size(y)-1:0]y_size;
 wire [3:0]z[0:5][0:7];
 wire [$size(z)-1:0]z_size;
 
-//
-// The following are not supported yet:
-//
-
-//wire [$bits(x)-1:0]x_bits;
-//wire [$bits({x, x})-1:0]xx_bits;
+wire [$bits(x)-1:0]x_bits;
+wire [$bits({x, x})-1:0]xx_bits;
+wire [$bits(y)-1:0]y_bits;
+wire [$bits(z)-1:0]z_bits;
 
 endmodule

--- a/tests/simple/functions01.sv
+++ b/tests/simple/functions01.sv
@@ -1,0 +1,15 @@
+module functions01;
+wire [3:0]x;
+wire [$size(x)-1:0]x_size;
+wire [$size({x, x})-1:0]xx_size;
+wire [3:0]w[0:5];
+
+//
+// The following are not supported yet:
+//
+
+//wire [$size(w)-1:0]w_s;
+//wire [$bits(x)-1:0]x_bits;
+//wire [$bits({x, x})-1:0]xx_bits;
+
+endmodule

--- a/tests/simple/functions01.sv
+++ b/tests/simple/functions01.sv
@@ -1,8 +1,8 @@
 module functions01;
 
-wire [3:0]x;
-wire [3:0]y[0:5];
-wire [3:0]z[0:5][0:7];
+wire [5:2]x;
+wire [3:0]y[2:7];
+wire [3:0]z[7:2][2:9];
 
 //wire [$size(x)-1:0]x_size;
 //wire [$size({x, x})-1:0]xx_size;
@@ -13,7 +13,14 @@ assert property ($size(x) == 4);
 assert property ($size({3{x}}) == 3*4);
 assert property ($size(y) == 6);
 assert property ($size(y, 1) == 6);
-assert property ($size(y, 2) == 4);
+assert property ($size(y, (1+1)) == 4);
+
+assert property ($size(z) == 6);
+assert property ($size(z, 1) == 6);
+assert property ($size(z, 2) == 8);
+assert property ($size(z, 3) == 4);
+// This should trigger an error if enabled (it does).
+//assert property ($size(z, 4) == 4);
 
 //wire [$bits(x)-1:0]x_bits;
 //wire [$bits({x, x})-1:0]xx_bits;
@@ -21,6 +28,5 @@ assert property ($size(y, 2) == 4);
 assert property ($bits(x) == 4);
 assert property ($bits(y) == 4*6);
 assert property ($bits(z) == 4*6*8);
-
 
 endmodule

--- a/tests/simple/functions01.sv
+++ b/tests/simple/functions01.sv
@@ -2,13 +2,15 @@ module functions01;
 wire [3:0]x;
 wire [$size(x)-1:0]x_size;
 wire [$size({x, x})-1:0]xx_size;
-wire [3:0]w[0:5];
+wire [3:0]y[0:5];
+wire [$size(y)-1:0]y_size;
+wire [3:0]z[0:5][0:7];
+wire [$size(z)-1:0]z_size;
 
 //
 // The following are not supported yet:
 //
 
-//wire [$size(w)-1:0]w_s;
 //wire [$bits(x)-1:0]x_bits;
 //wire [$bits({x, x})-1:0]xx_bits;
 

--- a/tests/simple/functions01.sv
+++ b/tests/simple/functions01.sv
@@ -1,16 +1,26 @@
 module functions01;
 
 wire [3:0]x;
-wire [$size(x)-1:0]x_size;
-wire [$size({x, x})-1:0]xx_size;
 wire [3:0]y[0:5];
-wire [$size(y)-1:0]y_size;
 wire [3:0]z[0:5][0:7];
-wire [$size(z)-1:0]z_size;
 
-wire [$bits(x)-1:0]x_bits;
-wire [$bits({x, x})-1:0]xx_bits;
-wire [$bits(y)-1:0]y_bits;
-wire [$bits(z)-1:0]z_bits;
+//wire [$size(x)-1:0]x_size;
+//wire [$size({x, x})-1:0]xx_size;
+//wire [$size(y)-1:0]y_size;
+//wire [$size(z)-1:0]z_size;
+
+assert property ($size(x) == 4);
+assert property ($size({3{x}}) == 3*4);
+assert property ($size(y) == 6);
+assert property ($size(y, 1) == 6);
+assert property ($size(y, 2) == 4);
+
+//wire [$bits(x)-1:0]x_bits;
+//wire [$bits({x, x})-1:0]xx_bits;
+
+assert property ($bits(x) == 4);
+assert property ($bits(y) == 4*6);
+assert property ($bits(z) == 4*6*8);
+
 
 endmodule


### PR DESCRIPTION
Reminder:
These are SystemVerilog extensions:
$size() yields the width of its argument (See IEEE-1800-2012 section 20.7)
$bits() yields the total number of bits of its argument (See IEEE-1800-2012 section 20.6.2)
For 1D bit vectors, these functions are the same.
For memories, $size() will yield the memory width while $bits() will yield the total number of bits taken to store this array.

I also added a small testcase to check the new functions, with assertions:
```
read_verilog -sv tests/simple/functions01.sv
sat -prove-asserts
```
The feature could use some further testing, using more complex expressions as arguments.
The 6 individual commits are just part of my working history. You can squash them to one commit.

I intend to keep adding SystemVerilog design features. I'm already working on adding typedefs (for simple types), then followed by aggregate members (struct).
I already have a typedef branch, but it is only partially implemented yet (parsing and AST construction only). I suspended working on it and moved to $bits() and $size() as these are easier, and  the knowledge I gained from implementing $bits() and $size() would help me with the next PRs.
