### PR TITLE
Resolved classical Bison IF/THEN/ELSE shift/reduce conflict using the…

### DIFF
--- a/frontends/verilog/verilog_parser.y
+++ b/frontends/verilog/verilog_parser.y
@@ -142,7 +142,9 @@ static void free_attr(std::map<std::string, AstNode*> *al)
 %define parse.error verbose
 %define parse.lac full
 
-%expect 2
+%nonassoc FAKE_THEN
+%nonassoc TOK_ELSE
+
 %debug
 
 %%
@@ -1261,7 +1263,7 @@ optional_else:
 		ast_stack.back()->children.push_back(cond);
 		ast_stack.push_back(block);
 	} behavioral_stmt |
-	/* empty */;
+	/* empty */ %prec FAKE_THEN;
 
 case_body:
 	case_body case_item |
@@ -1432,7 +1434,7 @@ gen_stmt_or_null:
 	gen_stmt_block | ';';
 
 opt_gen_else:
-	TOK_ELSE gen_stmt_or_null | /* empty */;
+	TOK_ELSE gen_stmt_or_null | /* empty */ %prec FAKE_THEN;
 
 expr:
 	basic_expr {


### PR DESCRIPTION
… textbook solution

(Oreilly 'Flex & Bison' page 188-189)

The current solution simply allows the Bison output to be used if it has exactly 2 conflicts.
This is less robust than this solution which explicitly solves these two if/then/else conflicts (one for normal if/then/else, the other within generate blocks)

patch passed 'make test'.
