### PR TITLE
Turned a few member functions into const, esp. dumpAst(), dumpVlog().

### DIFF
--- a/frontends/ast/ast.cc
+++ b/frontends/ast/ast.cc
@@ -212,7 +212,7 @@ AstNode::AstNode(AstNodeType type, AstNode *child1, AstNode *child2, AstNode *ch
 }
 
 // create a (deep recursive) copy of a node
-AstNode *AstNode::clone()
+AstNode *AstNode::clone() const
 {
 	AstNode *that = new AstNode;
 	*that = *this;
@@ -224,7 +224,7 @@ AstNode *AstNode::clone()
 }
 
 // create a (deep recursive) copy of a node use 'other' as target root node
-void AstNode::cloneInto(AstNode *other)
+void AstNode::cloneInto(AstNode *other) const
 {
 	AstNode *tmp = clone();
 	other->delete_children();
@@ -254,7 +254,7 @@ AstNode::~AstNode()
 
 // create a nice text representation of the node
 // (traverse tree by recursion, use 'other' pointer for diffing two AST trees)
-void AstNode::dumpAst(FILE *f, std::string indent)
+void AstNode::dumpAst(FILE *f, std::string indent) const
 {
 	if (f == NULL) {
 		for (auto f : log_files)
@@ -333,7 +333,7 @@ static std::string id2vl(std::string txt)
 }
 
 // dump AST node as Verilog pseudo-code
-void AstNode::dumpVlog(FILE *f, std::string indent)
+void AstNode::dumpVlog(FILE *f, std::string indent) const
 {
 	bool first = true;
 	std::string txt;
@@ -755,7 +755,7 @@ AstNode *AstNode::mkconst_str(const std::string &str)
 	return node;
 }
 
-bool AstNode::bits_only_01()
+bool AstNode::bits_only_01() const
 {
 	for (auto bit : bits)
 		if (bit != RTLIL::S0 && bit != RTLIL::S1)
@@ -806,7 +806,7 @@ RTLIL::Const AstNode::asParaConst()
 	return val;
 }
 
-bool AstNode::asBool()
+bool AstNode::asBool() const
 {
 	log_assert(type == AST_CONSTANT);
 	for (auto &bit : bits)
@@ -815,7 +815,7 @@ bool AstNode::asBool()
 	return false;
 }
 
-int AstNode::isConst()
+int AstNode::isConst() const
 {
 	if (type == AST_CONSTANT)
 		return 1;

--- a/frontends/ast/ast.h
+++ b/frontends/ast/ast.h
@@ -190,8 +190,8 @@ namespace AST
 
 		// creating and deleting nodes
 		AstNode(AstNodeType type = AST_NONE, AstNode *child1 = NULL, AstNode *child2 = NULL, AstNode *child3 = NULL);
-		AstNode *clone();
-		void cloneInto(AstNode *other);
+		AstNode *clone() const;
+		void cloneInto(AstNode *other) const;
 		void delete_children();
 		~AstNode();
 
@@ -234,8 +234,8 @@ namespace AST
 		AstNode *eval_const_function(AstNode *fcall);
 
 		// create a human-readable text representation of the AST (for debugging)
-		void dumpAst(FILE *f, std::string indent);
-		void dumpVlog(FILE *f, std::string indent);
+		void dumpAst(FILE *f, std::string indent) const;
+		void dumpVlog(FILE *f, std::string indent) const;
 
 		// used by genRTLIL() for detecting expression width and sign
 		void detectSignWidthWorker(int &width_hint, bool &sign_hint, bool *found_real = NULL);
@@ -264,11 +264,11 @@ namespace AST
 		RTLIL::Const asAttrConst();
 		RTLIL::Const asParaConst();
 		uint64_t asInt(bool is_signed);
-		bool bits_only_01();
-		bool asBool();
+		bool bits_only_01() const;
+		bool asBool() const;
 
 		// helper functions for real valued const eval
-		int isConst(); // return '1' for AST_CONSTANT and '2' for AST_REALVALUE
+		int isConst() const; // return '1' for AST_CONSTANT and '2' for AST_REALVALUE
 		double asReal(bool is_signed);
 		RTLIL::Const realAsConst(int width);
 	};


### PR DESCRIPTION
This is really a minor PR.
While working on a different change I wanted to create a const AstNode to be sure I'm not modifying it, only to discover I can't dump it.
After changing dumpAst() and dumpVlog() to const, I tagged a few other functions which are also clearly const.
This also passed 'make test'