### PR TITLE
Fix input vector for reduce cells.

### DIFF
--- a/passes/opt/opt_reduce.cc
+++ b/passes/opt/opt_reduce.cc
@@ -88,6 +88,7 @@ struct OptReduceWorker
 		RTLIL::SigSpec new_sig_a(new_sig_a_bits);
 
 		if (new_sig_a != sig_a || sig_a.size() != cell->getPort("\\A").size()) {
+			new_sig_a.sort_and_unify();
 			log("    New input vector for %s cell %s: %s\n", cell->type.c_str(), cell->name.c_str(), log_signal(new_sig_a));
 			did_something = true;
 			total_count++;


### PR DESCRIPTION
Test unit.
```
module test(input [3:0] a, input [3:0] b, output w);
  assign w = |{a[3], a[1], a[2], a[0], b[3], b[1], b[2], b[0]};
endmodule
```
Now: New input vector for $reduce_or cell $reduce_or$mini_redu.v:2$1: { \a [0] \a [1] \a [2] \a [3] \b [0] \b [1] \b [2] \b [3] }

Fixed to: New input vector for $reduce_or cell $reduce_or$mini_redu.v:2$1: { \b \a }
