### PR TITLE
Add UltraPlus specific cells to ice40 techlib

### DIFF
--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -883,7 +883,7 @@ module SB_WARMBOOT (
 endmodule
 
 // UltraPlus feature cells
-(* blackbox, keep *)
+(* blackbox *)
 module SB_MAC16 (
 	input CLK,
 	input CE,
@@ -935,7 +935,7 @@ parameter A_SIGNED = 1'b0;
 parameter B_SIGNED = 1'b0;
 endmodule
 
-(* blackbox, keep *)
+(* blackbox *)
 module SB_SPRAM256KA(
 	input [13:0] ADDRESS,
 	input [15:0] DATAIN,
@@ -950,7 +950,7 @@ module SB_SPRAM256KA(
 );
 endmodule
 
-(* blackbox, keep *)
+(* blackbox *)
 module SB_HFOSC(
 	input CLKHFPU,
 	input CLKHFEN,
@@ -959,7 +959,7 @@ module SB_HFOSC(
 parameter CLKHF_DIV = "0b00";
 endmodule
 
-(* blackbox, keep *)
+(* blackbox *)
 module SB_LFOSC(
 	input CLKLFPU,
 	input CLKLFEN,
@@ -967,7 +967,7 @@ module SB_LFOSC(
 );
 endmodule
 
-(* blackbox, keep *)
+(* blackbox *)
 module SB_RGBA_DRV(
 	input CURREN,
 	input RGBLEDEN,

--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -881,3 +881,106 @@ module SB_WARMBOOT (
 	input S0
 );
 endmodule
+
+// UltraPlus feature cells
+(* blackbox, keep *)
+module SB_MAC16 (
+	input CLK,
+	input CE,
+	input [15:0] C,
+	input [15:0] A,
+	input [15:0] B,
+	input [15:0] D,
+	input AHOLD,
+	input BHOLD,
+	input CHOLD,
+	input DHOLD,
+	input IRSTTOP,
+	input IRSTBOT,
+	input ORSTTOP,
+	input ORSTBOT,
+	input OLOADTOP,
+	input OLOADBOT,
+	input ADDSUBTOP,
+	input ADDSUBBOT,
+	input OHOLDTOP,
+	input OHOLDBOT,
+	input CI,
+	input ACCUMCI,
+	input SIGNEXTIN,
+	output [31:0] O,
+	output CO,
+	output ACCUMCO,
+	output SIGNEXTOUT
+); 
+parameter NEG_TRIGGER = 1'b0;
+parameter C_REG = 1'b0;
+parameter A_REG = 1'b0;
+parameter B_REG = 1'b0;
+parameter D_REG = 1'b0;
+parameter TOP_8x8_MULT_REG = 1'b0;
+parameter BOT_8x8_MULT_REG = 1'b0;
+parameter PIPELINE_16x16_MULT_REG1 = 1'b0;
+parameter PIPELINE_16x16_MULT_REG2 = 1'b0;
+parameter TOPOUTPUT_SELECT =  2'b00;
+parameter TOPADDSUB_LOWERINPUT = 2'b00;
+parameter TOPADDSUB_UPPERINPUT = 1'b0;
+parameter TOPADDSUB_CARRYSELECT = 2'b00;
+parameter BOTOUTPUT_SELECT =  2'b00;
+parameter BOTADDSUB_LOWERINPUT = 2'b00;
+parameter BOTADDSUB_UPPERINPUT = 1'b0;
+parameter BOTADDSUB_CARRYSELECT = 2'b00;
+parameter MODE_8x8 = 1'b0;
+parameter A_SIGNED = 1'b0;
+parameter B_SIGNED = 1'b0;
+endmodule
+
+(* blackbox, keep *)
+module SB_SPRAM256KA(
+	input [13:0] ADDRESS,
+	input [15:0] DATAIN,
+	input [3:0] MASKWREN,
+	input WREN,
+	input CHIPSELECT,
+	input CLOCK,
+	input STANDBY,
+	input SLEEP,
+	input POWEROFF,
+	output [15:0] DATAOUT
+);
+endmodule
+
+(* blackbox, keep *)
+module SB_HFOSC(
+	input CLKHFPU,
+	input CLKHFEN,
+	output CLKHF
+);
+parameter CLKHF_DIV = "0b00";
+endmodule
+
+(* blackbox, keep *)
+module SB_LFOSC(
+	input CLKLFPU,
+	input CLKLFEN,
+	output CLKLF
+);
+endmodule
+
+(* blackbox, keep *)
+module SB_RGBA_DRV(
+	input CURREN,
+	input RGBLEDEN,
+	input RGB0PWM,
+	input RGB1PWM,
+	input RGB2PWM,
+	output RGB0,
+	output RGB1,
+	output RGB2
+);
+parameter CURRENT_MODE = "0b0";
+parameter RGB0_CURRENT = "0b000000";
+parameter RGB1_CURRENT = "0b000000";
+parameter RGB2_CURRENT = "0b000000";
+endmodule
+


### PR DESCRIPTION
This adds `SB_MAC16`, `SB_SPRAM256KA`, `SB_HFOSC`, `SB_LFOSC` and `SB_RGBA_DRV` to the ice40 `cells_sim.v`.

It does not yet contain simulation models or any support for inference for any of these new primitives.