### PR TITLE
Add remaining UltraPlus cells to ice40 techlib

### DIFF
--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -984,3 +984,266 @@ parameter RGB1_CURRENT = "0b000000";
 parameter RGB2_CURRENT = "0b000000";
 endmodule
 
+(* blackbox *)
+module SB_I2C(
+	input  SBCLKI,
+	input  SBRWI,
+	input  SBSTBI,
+	input  SBADRI7,
+	input  SBADRI6,
+	input  SBADRI5,
+	input  SBADRI4,
+	input  SBADRI3,
+	input  SBADRI2,
+	input  SBADRI1,
+	input  SBADRI0,
+	input  SBDATI7,
+	input  SBDATI6,
+	input  SBDATI5,
+	input  SBDATI4,
+	input  SBDATI3,
+	input  SBDATI2,
+	input  SBDATI1,
+	input  SBDATI0,
+	input  SCLI,
+	input  SDAI,
+	output SBDATO7,
+	output SBDATO6,
+	output SBDATO5,
+	output SBDATO4,
+	output SBDATO3,
+	output SBDATO2,
+	output SBDATO1,
+	output SBDATO0,
+	output SBACKO,
+	output I2CIRQ,
+	output I2CWKUP,
+	output SCLO, //inout in the SB verilog library, but output in the VHDL and PDF libs and seemingly in the HW itself
+	output SCLOE,
+	output SDAO,
+	output SDAOE
+);
+parameter I2C_SLAVE_INIT_ADDR = "0b1111100001";
+parameter BUS_ADDR74 = "0b0001";
+endmodule
+
+(* blackbox *)
+module SB_SPI (
+	input  SBCLKI,
+	input  SBRWI,				   
+	input  SBSTBI,
+	input  SBADRI7,
+	input  SBADRI6,
+	input  SBADRI5,
+	input  SBADRI4,
+	input  SBADRI3,
+	input  SBADRI2,
+	input  SBADRI1,
+	input  SBADRI0,
+	input  SBDATI7,
+	input  SBDATI6,
+	input  SBDATI5,
+	input  SBDATI4,
+	input  SBDATI3,
+	input  SBDATI2,
+	input  SBDATI1,
+	input  SBDATI0,
+	input  MI,
+	input  SI,
+	input  SCKI,
+	input  SCSNI,
+	output SBDATO7,
+	output SBDATO6,
+	output SBDATO5,
+	output SBDATO4,
+	output SBDATO3,
+	output SBDATO2,
+	output SBDATO1,
+	output SBDATO0,
+	output SBACKO,
+	output SPIIRQ,
+	output SPIWKUP,
+	output SO,
+	output SOE,
+	output MO,
+	output MOE,
+	output SCKO, //inout in the SB verilog library, but output in the VHDL and PDF libs and seemingly in the HW itself
+	output SCKOE,
+	output MCSNO3,
+	output MCSNO2,
+	output MCSNO1,
+	output MCSNO0,
+	output MCSNOE3,
+	output MCSNOE2,
+	output MCSNOE1,
+	output MCSNOE0
+);
+parameter BUS_ADDR74 = "0b0000";
+endmodule
+
+(* blackbox *)
+module SB_LEDDA_IP(
+	input LEDDCS,
+	input LEDDCLK,
+	input LEDDDAT7,
+	input LEDDDAT6,
+	input LEDDDAT5,
+	input LEDDDAT4,
+	input LEDDDAT3,
+	input LEDDDAT2,
+	input LEDDDAT1,
+	input LEDDDAT0,
+	input LEDDADDR3,
+	input LEDDADDR2,
+	input LEDDADDR1,
+	input LEDDADDR0,
+	input LEDDDEN,
+	input LEDDEXE,
+	input LEDDRST,
+	output PWMOUT0,
+	output PWMOUT1,
+	output PWMOUT2,
+	output LEDDON
+);
+endmodule
+
+(* blackbox *)
+module SB_FILTER_50NS(
+	input FILTERIN,
+	output FILTEROUT
+);
+endmodule
+
+module SB_IO_I3C (
+	inout  PACKAGE_PIN,
+	input  LATCH_INPUT_VALUE,
+	input  CLOCK_ENABLE,
+	input  INPUT_CLK,
+	input  OUTPUT_CLK,
+	input  OUTPUT_ENABLE,
+	input  D_OUT_0,
+	input  D_OUT_1,
+	output D_IN_0,
+	output D_IN_1,
+	input  PU_ENB, 
+	input  WEAK_PU_ENB
+);
+	parameter [5:0] PIN_TYPE = 6'b000000;
+	parameter [0:0] PULLUP = 1'b0;
+	parameter [0:0] WEAK_PULLUP = 1'b0;
+	parameter [0:0] NEG_TRIGGER = 1'b0;
+	parameter IO_STANDARD = "SB_LVCMOS";
+
+`ifndef BLACKBOX
+	reg dout, din_0, din_1;
+	reg din_q_0, din_q_1;
+	reg dout_q_0, dout_q_1;
+	reg outena_q;
+
+	generate if (!NEG_TRIGGER) begin
+		always @(posedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_0  <= PACKAGE_PIN;
+		always @(negedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_1  <= PACKAGE_PIN;
+		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_0 <= D_OUT_0;
+		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_1 <= D_OUT_1;
+		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) outena_q <= OUTPUT_ENABLE;
+	end else begin
+		always @(negedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_0  <= PACKAGE_PIN;
+		always @(posedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_1  <= PACKAGE_PIN;
+		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_0 <= D_OUT_0;
+		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_1 <= D_OUT_1;
+		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) outena_q <= OUTPUT_ENABLE;
+	end endgenerate
+
+	always @* begin
+		if (!PIN_TYPE[1] || !LATCH_INPUT_VALUE)
+			din_0 = PIN_TYPE[0] ? PACKAGE_PIN : din_q_0;
+		din_1 = din_q_1;
+	end
+
+	// work around simulation glitches on dout in DDR mode
+	reg outclk_delayed_1;
+	reg outclk_delayed_2;
+	always @* outclk_delayed_1 <= OUTPUT_CLK;
+	always @* outclk_delayed_2 <= outclk_delayed_1;
+
+	always @* begin
+		if (PIN_TYPE[3])
+			dout = PIN_TYPE[2] ? !dout_q_0 : D_OUT_0;
+		else
+			dout = (outclk_delayed_2 ^ NEG_TRIGGER) || PIN_TYPE[2] ? dout_q_0 : dout_q_1;
+	end
+
+	assign D_IN_0 = din_0, D_IN_1 = din_1;
+
+	generate
+		if (PIN_TYPE[5:4] == 2'b01) assign PACKAGE_PIN = dout;
+		if (PIN_TYPE[5:4] == 2'b10) assign PACKAGE_PIN = OUTPUT_ENABLE ? dout : 1'bz;
+		if (PIN_TYPE[5:4] == 2'b11) assign PACKAGE_PIN = outena_q ? dout : 1'bz;
+	endgenerate
+`endif
+endmodule
+
+module SB_IO_OD (
+	inout  PACKAGEPIN,
+	input  LATCHINPUTVALUE,
+	input  CLOCKENABLE,
+	input  INPUTCLK,
+	input  OUTPUTCLK,
+	input  OUTPUTENABLE,
+	input  DOUT1,
+	input  DOUT0,
+	output DIN1,
+	output DIN0,
+);
+	parameter [5:0] PIN_TYPE = 6'b000000;
+	parameter [0:0] NEG_TRIGGER = 1'b0;
+
+`ifndef BLACKBOX
+	reg dout, din_0, din_1;
+	reg din_q_0, din_q_1;
+	reg dout_q_0, dout_q_1;
+	reg outena_q;
+
+	generate if (!NEG_TRIGGER) begin
+		always @(posedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_0  <= PACKAGE_PIN;
+		always @(negedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_1  <= PACKAGE_PIN;
+		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_0 <= D_OUT_0;
+		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_1 <= D_OUT_1;
+		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) outena_q <= OUTPUT_ENABLE;
+	end else begin
+		always @(negedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_0  <= PACKAGE_PIN;
+		always @(posedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_1  <= PACKAGE_PIN;
+		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_0 <= D_OUT_0;
+		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_1 <= D_OUT_1;
+		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) outena_q <= OUTPUT_ENABLE;
+	end endgenerate
+
+	always @* begin
+		if (!PIN_TYPE[1] || !LATCH_INPUT_VALUE)
+			din_0 = PIN_TYPE[0] ? PACKAGE_PIN : din_q_0;
+		din_1 = din_q_1;
+	end
+
+	// work around simulation glitches on dout in DDR mode
+	reg outclk_delayed_1;
+	reg outclk_delayed_2;
+	always @* outclk_delayed_1 <= OUTPUT_CLK;
+	always @* outclk_delayed_2 <= outclk_delayed_1;
+
+	always @* begin
+		if (PIN_TYPE[3])
+			dout = PIN_TYPE[2] ? !dout_q_0 : D_OUT_0;
+		else
+			dout = (outclk_delayed_2 ^ NEG_TRIGGER) || PIN_TYPE[2] ? dout_q_0 : dout_q_1;
+	end
+
+	assign D_IN_0 = din_0, D_IN_1 = din_1;
+
+	generate
+		if (PIN_TYPE[5:4] == 2'b01) assign PACKAGE_PIN = dout ? 1'bz : 1'b0;
+		if (PIN_TYPE[5:4] == 2'b10) assign PACKAGE_PIN = OUTPUT_ENABLE ? (dout ? 1'bz : 1'b0) : 1'bz;
+		if (PIN_TYPE[5:4] == 2'b11) assign PACKAGE_PIN = outena_q ? (dout ? 1'bz : 1'b0) : 1'bz;
+	endgenerate
+`endif
+endmodule
+


### PR DESCRIPTION
This adds support for all of the iCE40 UltraPlus cells not added in the previous pull request, including the I2C and SPI hard IP. It also adds SB_IO_OD and SB_IO_I3C and simulation models for these (which in both cases were trivial changes to the existing SB_IO model).