### PR TITLE
Fix SB_IO_OD module

### DIFF
--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -1205,44 +1205,44 @@ module SB_IO_OD (
 	reg outena_q;
 
 	generate if (!NEG_TRIGGER) begin
-		always @(posedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_0  <= PACKAGE_PIN;
-		always @(negedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_1  <= PACKAGE_PIN;
-		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_0 <= D_OUT_0;
-		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_1 <= D_OUT_1;
-		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) outena_q <= OUTPUT_ENABLE;
+		always @(posedge INPUTCLK)  if (CLOCKENABLE) din_q_0  <= PACKAGEPIN;
+		always @(negedge INPUTCLK)  if (CLOCKENABLE) din_q_1  <= PACKAGEPIN;
+		always @(posedge OUTPUTCLK) if (CLOCKENABLE) dout_q_0 <= DOUT0;
+		always @(negedge OUTPUTCLK) if (CLOCKENABLE) dout_q_1 <= DOUT1;
+		always @(posedge OUTPUTCLK) if (CLOCKENABLE) outena_q <= OUTPUTENABLE;
 	end else begin
-		always @(negedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_0  <= PACKAGE_PIN;
-		always @(posedge INPUT_CLK)  if (CLOCK_ENABLE) din_q_1  <= PACKAGE_PIN;
-		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_0 <= D_OUT_0;
-		always @(posedge OUTPUT_CLK) if (CLOCK_ENABLE) dout_q_1 <= D_OUT_1;
-		always @(negedge OUTPUT_CLK) if (CLOCK_ENABLE) outena_q <= OUTPUT_ENABLE;
+		always @(negedge INPUTCLK)  if (CLOCKENABLE) din_q_0  <= PACKAGEPIN;
+		always @(posedge INPUTCLK)  if (CLOCKENABLE) din_q_1  <= PACKAGEPIN;
+		always @(negedge OUTPUTCLK) if (CLOCKENABLE) dout_q_0 <= DOUT0;
+		always @(posedge OUTPUTCLK) if (CLOCKENABLE) dout_q_1 <= DOUT1;
+		always @(negedge OUTPUTCLK) if (CLOCKENABLE) outena_q <= OUTPUTENABLE;
 	end endgenerate
 
 	always @* begin
-		if (!PIN_TYPE[1] || !LATCH_INPUT_VALUE)
-			din_0 = PIN_TYPE[0] ? PACKAGE_PIN : din_q_0;
+		if (!PIN_TYPE[1] || !LATCHINPUTVALUE)
+			din_0 = PIN_TYPE[0] ? PACKAGEPIN : din_q_0;
 		din_1 = din_q_1;
 	end
 
 	// work around simulation glitches on dout in DDR mode
 	reg outclk_delayed_1;
 	reg outclk_delayed_2;
-	always @* outclk_delayed_1 <= OUTPUT_CLK;
+	always @* outclk_delayed_1 <= OUTPUTCLK;
 	always @* outclk_delayed_2 <= outclk_delayed_1;
 
 	always @* begin
 		if (PIN_TYPE[3])
-			dout = PIN_TYPE[2] ? !dout_q_0 : D_OUT_0;
+			dout = PIN_TYPE[2] ? !dout_q_0 : DOUT0;
 		else
 			dout = (outclk_delayed_2 ^ NEG_TRIGGER) || PIN_TYPE[2] ? dout_q_0 : dout_q_1;
 	end
 
-	assign D_IN_0 = din_0, D_IN_1 = din_1;
+	assign DIN0 = din_0, DIN1 = din_1;
 
 	generate
-		if (PIN_TYPE[5:4] == 2'b01) assign PACKAGE_PIN = dout ? 1'bz : 1'b0;
-		if (PIN_TYPE[5:4] == 2'b10) assign PACKAGE_PIN = OUTPUT_ENABLE ? (dout ? 1'bz : 1'b0) : 1'bz;
-		if (PIN_TYPE[5:4] == 2'b11) assign PACKAGE_PIN = outena_q ? (dout ? 1'bz : 1'b0) : 1'bz;
+		if (PIN_TYPE[5:4] == 2'b01) assign PACKAGEPIN = dout ? 1'bz : 1'b0;
+		if (PIN_TYPE[5:4] == 2'b10) assign PACKAGEPIN = OUTPUTENABLE ? (dout ? 1'bz : 1'b0) : 1'bz;
+		if (PIN_TYPE[5:4] == 2'b11) assign PACKAGEPIN = outena_q ? (dout ? 1'bz : 1'b0) : 1'bz;
 	endgenerate
 `endif
 endmodule

--- a/techlibs/ice40/cells_sim.v
+++ b/techlibs/ice40/cells_sim.v
@@ -1193,7 +1193,7 @@ module SB_IO_OD (
 	input  DOUT1,
 	input  DOUT0,
 	output DIN1,
-	output DIN0,
+	output DIN0
 );
 	parameter [5:0] PIN_TYPE = 6'b000000;
 	parameter [0:0] NEG_TRIGGER = 1'b0;


### PR DESCRIPTION
This PR fixes two mistakes that were preventing Icarus from being able to parse the `SB_IO_OD` module:

* Removes the trailing comma at the end of the port list. Although Yosys supports this syntax, Icarus doesn't seem to and it's inconsistent with all the other modules in `ice40/cells_sim.sv`.
* Fixes port names inside the body of the module - the port names are declared without underscores (and although this is inconsistent with the similar `SB_IO` module, it is correct according to the technology library PDF and existing code on the Internet) but the body attempted to refer to the ports with underscores in the names.