### PR TITLE
Use quote includes for yosys.h

### DIFF
--- a/kernel/celltypes.h
+++ b/kernel/celltypes.h
@@ -20,7 +20,7 @@
 #ifndef CELLTYPES_H
 #define CELLTYPES_H
 
-#include <kernel/yosys.h>
+#include "kernel/yosys.h"
 
 YOSYS_NAMESPACE_BEGIN
 

--- a/kernel/cost.h
+++ b/kernel/cost.h
@@ -20,7 +20,7 @@
 #ifndef COST_H
 #define COST_H
 
-#include <kernel/yosys.h>
+#include "kernel/yosys.h"
 
 YOSYS_NAMESPACE_BEGIN
 


### PR DESCRIPTION
I'm building Yosys using Bazel, and I noticed that you're using <> includes for some non-system headers. Changing this makes it easier to build since Bazel can be picky about how files get included.